### PR TITLE
Remove npm dependencies from CI workflow

### DIFF
--- a/.github/workflows/scripts/package.json
+++ b/.github/workflows/scripts/package.json
@@ -8,14 +8,6 @@
     },
     "keywords": [],
     "author": "",
-    "dependencies": {
-      "@types/node": "^18.0.6",
-      "axios": "^1.4.0",
-      "dotenv": "^16.0.3",
-      "form-data": "^4.0.0",
-      "node-fetch": "^3.2.6"
-    },
-    "devDependencies": {
-      "unzip": "^0.1.11"
-    }
+    "dependencies": {},
+    "devDependencies": {}
   }

--- a/.github/workflows/scripts/updateTheme.js
+++ b/.github/workflows/scripts/updateTheme.js
@@ -1,61 +1,67 @@
-const axios = require('axios');
 const fs = require('fs');
-const FormData = require('form-data');
-
+const path = require('path');
 
 // Validate required environment variables
-if (!process.env['ZENDESK_SUBDOMAIN'] || !process.env['ZENDESK_EMAIL'] || !process.env['ZENDESK_TOKEN'], !process.env['THEME_ID']) {
+if (!process.env['ZENDESK_SUBDOMAIN'] || !process.env['ZENDESK_EMAIL'] || !process.env['ZENDESK_TOKEN'] || !process.env['THEME_ID']) {
     console.error('Missing required environment variables: ZENDESK_SUBDOMAIN, ZENDESK_EMAIL, ZENDESK_TOKEN, THEME_ID');
     process.exit(1);
 }
 
-var authValue = Buffer.from(`${process.env['ZENDESK_EMAIL']}/token:${process.env['ZENDESK_TOKEN']}`).toString('base64')
-
-const instance = axios.create({
-    baseURL: `https://${process.env['ZENDESK_SUBDOMAIN']}.zendesk.com/api/v2`,
-    headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Basic ${authValue}`, // Base64 encoded "username:token"
-    }
-});
-
+const authValue = Buffer.from(`${process.env['ZENDESK_EMAIL']}/token:${process.env['ZENDESK_TOKEN']}`).toString('base64');
+const baseURL = `https://${process.env['ZENDESK_SUBDOMAIN']}.zendesk.com/api/v2`;
 const themeId = process.env['THEME_ID'];
-const filePath = './.github/workflows/scripts/theme.zip';
+const filePath = path.join(__dirname, 'theme.zip');
 const replaceSettings = true;
-
 const MAX_WAIT_TIME = 5 * 60 * 1000;
+
+async function zendeskFetch(endpoint, options = {}) {
+    const url = `${baseURL}${endpoint}`;
+    const response = await fetch(url, {
+        ...options,
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Basic ${authValue}`,
+            ...options.headers,
+        },
+    });
+    if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`${response.status} ${response.statusText}: ${text}`);
+    }
+    return response.json();
+}
 
 async function updateTheme(themeId, replaceSettings) {
     try {
-        const response = await instance.post(`/guide/theming/jobs/themes/updates`, {
-            job: {
-                attributes: {
-                    theme_id: themeId,
-                    replace_settings: replaceSettings,
-                    format: "zip"
+        const data = await zendeskFetch('/guide/theming/jobs/themes/updates', {
+            method: 'POST',
+            body: JSON.stringify({
+                job: {
+                    attributes: {
+                        theme_id: themeId,
+                        replace_settings: replaceSettings,
+                        format: "zip"
+                    }
                 }
-            }
+            }),
         });
+
         console.log('::group::Update Theme Response');
-        const prettyResponse = JSON.stringify(response.data, null, 2);
+        const prettyResponse = JSON.stringify(data, null, 2);
         console.log(prettyResponse);
         console.log('::endgroup::');
-
         fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Update Theme Response\n\`\`\`json\n${prettyResponse}\n\`\`\``);
 
         return {
-            jobId: response.data.job.id,
-            uploadUrl: response.data.job.data.upload.url,
-            uploadParameters: response.data.job.data.upload.parameters
+            jobId: data.job.id,
+            uploadUrl: data.job.data.upload.url,
+            uploadParameters: data.job.data.upload.parameters
         };
     } catch (error) {
         console.log('::group::Action failed with error');
-        const prettyError = JSON.stringify(error, null, 2);
-        console.log(prettyError);
+        console.log(error.message);
         console.log('::endgroup::');
-
-        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Update Theme Error\n\`\`\`json\n${prettyError}\n\`\`\``);
-
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Update Theme Error\n\`\`\`\n${error.message}\n\`\`\``);
         process.exit(1);
     }
 }
@@ -67,54 +73,51 @@ async function uploadThemeFile(uploadUrl, uploadParameters, filePath) {
         form.append(key, uploadParameters[key]);
     }
 
-    let readStream;
-    try {
-        readStream = fs.createReadStream(filePath);
-    } catch (error) {
-        console.error('Error reading file:', error);
-        process.exit(1);
-    }
-    form.append('file', readStream);
+    const fileBuffer = fs.readFileSync(filePath);
+    const blob = new Blob([fileBuffer]);
+    form.append('file', blob, 'theme.zip');
 
     try {
-        const response = await axios.post(uploadUrl, form, { headers: form.getHeaders() });
+        const response = await fetch(uploadUrl, {
+            method: 'POST',
+            body: form,
+        });
+
+        const text = await response.text();
         console.log('::group::Upload Theme File Response');
-        const prettyResponse = JSON.stringify(response.data, null, 2);
-        console.log(prettyResponse);
+        console.log(text);
         console.log('::endgroup::');
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Upload Theme File Response\n\`\`\`\n${text}\n\`\`\``);
 
-        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Upload Theme File Response\n\`\`\`json\n${prettyResponse}\n\`\`\``);
+        if (!response.ok) {
+            throw new Error(`Upload failed: ${response.status} ${response.statusText}`);
+        }
     } catch (error) {
         console.log('::group::Action failed with error');
-        const prettyError = JSON.stringify(error, null, 2);
-        console.log(prettyError);
+        console.log(error.message);
         console.log('::endgroup::');
-
-        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Upload Theme File Error\n\`\`\`json\n${prettyError}\n\`\`\``);
-
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Upload Theme File Error\n\`\`\`\n${error.message}\n\`\`\``);
         process.exit(1);
     }
 }
 
 async function checkUpdateJobStatus(jobId) {
     try {
-        const response = await instance.get(`/guide/theming/jobs/${jobId}`);
-        if (response.data.job.status !== 'pending') {
+        const data = await zendeskFetch(`/guide/theming/jobs/${jobId}`, { method: 'GET' });
+
+        if (data.job.status !== 'pending') {
             console.log('::group::Check Update Job Status Response');
-            const prettyResponse = JSON.stringify(response.data, null, 2);
+            const prettyResponse = JSON.stringify(data, null, 2);
             console.log(prettyResponse);
             console.log('::endgroup::');
             fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Check Update Job Status Response\n\`\`\`json\n${prettyResponse}\n\`\`\``);
         }
-        return response.data.job;
+        return data.job;
     } catch (error) {
         console.log('::group::Action failed with error');
-        const prettyError = JSON.stringify(error, null, 2);
-        console.log(prettyError);
+        console.log(error.message);
         console.log('::endgroup::');
-
-        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Check Update Job Status Error\n\`\`\`json\n${prettyError}\n\`\`\``);
-
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Check Update Job Status Error\n\`\`\`\n${error.message}\n\`\`\``);
         process.exit(1);
     }
 }
@@ -130,7 +133,7 @@ async function run() {
 
         let jobStatus = await checkUpdateJobStatus(jobId);
         const startTime = Date.now();
-        let attemptInterval = 5000; // Starting interval for polling
+        let attemptInterval = 5000;
 
         while (jobStatus.status !== 'completed' && jobStatus.status !== 'failed') {
             if (Date.now() - startTime > MAX_WAIT_TIME) {
@@ -142,7 +145,7 @@ async function run() {
             await new Promise(resolve => setTimeout(resolve, attemptInterval));
 
             jobStatus = await checkUpdateJobStatus(jobId);
-            attemptInterval = Math.min(attemptInterval * 1.5, 60000); // Increase interval to a maximum of 60 seconds
+            attemptInterval = Math.min(attemptInterval * 1.5, 60000);
         }
 
         if (jobStatus.status === 'failed') {

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,12 +18,9 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.x
-
-      - name: Install dependencies
-        run: npm ci --prefix ./.github/workflows/scripts/
+          node-version: 20.x
 
       - name: Zip theme files
         run: |

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen 12-30.2",
   "author": "Zendesk",
-  "version": "4.23.7",
+  "version": "4.23.8",
   "api_version": 4,
   "default_locale": "en-us",
   "settings": [


### PR DESCRIPTION
## Summary

- **Removes all npm dependencies** (axios, form-data, dotenv, node-fetch, etc.) from the theme update workflow by upgrading to Node 20, which has built-in `fetch` and `FormData`
- Eliminates the `npm ci` step entirely — no packages to install, no supply chain to worry about
- Fixes a bug where the env variable validation used a comma operator instead of `||`, silently skipping checks for `ZENDESK_SUBDOMAIN`, `ZENDESK_EMAIL`, and `ZENDESK_TOKEN`

## Why

Axios was hit by a supply chain attack last week. Rather than pin, audit, or swap to another package, the better question is: why have dependencies at all if we can avoid them? Node 20 ships with everything this script needs natively. Zero dependencies means zero supply chain risk.

GitHub is also currently flagging [48 vulnerabilities](https://github.com/ARPA-H/zendesk_copenhagen/security/dependabot) on this repo's default branch — this PR eliminates a chunk of that surface area.

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` against sandbox to verify the theme update still works end-to-end
- [ ] Confirm the `npm ci` step is gone and no `node_modules` are created
- [ ] Verify the job summary output still renders correctly in the Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)