### PR TITLE
Harden CI workflow: redact credentials, upgrade actions

### DIFF
--- a/.github/workflows/scripts/updateTheme.js
+++ b/.github/workflows/scripts/updateTheme.js
@@ -46,8 +46,16 @@ async function updateTheme(themeId, replaceSettings) {
             }),
         });
 
+        const safeData = {
+            job: {
+                id: data.job.id,
+                status: data.job.status,
+                upload_url: data.job.data.upload.url,
+                upload_parameters: '[REDACTED]'
+            }
+        };
         console.log('::group::Update Theme Response');
-        const prettyResponse = JSON.stringify(data, null, 2);
+        const prettyResponse = JSON.stringify(safeData, null, 2);
         console.log(prettyResponse);
         console.log('::endgroup::');
         fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Update Theme Response\n\`\`\`json\n${prettyResponse}\n\`\`\``);

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
-        
+        uses: actions/checkout@v6
+
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       - name: Zip theme files
         run: |
@@ -36,7 +36,7 @@ jobs:
           THEME_ID: ${{ (github.ref_name == 'sandbox' || github.base_ref == 'sandbox') && secrets.SANDBOX_THEME_ID || secrets.THEME_ID }}
 
       - name: Upload theme file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: theme-file
           path: ./.github/workflows/scripts/theme.zip


### PR DESCRIPTION
## Summary

- **Redact AWS upload credentials** from GitHub Actions logs and step summaries — the Zendesk API returns temporary S3 tokens that were previously logged in full, visible to anyone with repo read access
- **Upgrade all GitHub Actions** to Node 24-compatible versions ahead of the June 2026 deprecation deadline: checkout v4→v6, setup-node v4→v6, upload-artifact v4→v7
- **Bump node-version** from 20.x to 22.x (current LTS)

## Test plan

- [x] Trigger workflow via `workflow_dispatch` and confirm the step summary no longer contains AWS credentials
- [x] Verify no Node.js 20 deprecation warnings in the action logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)