### PR TITLE
Add styling to wrap long names on request page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.44.1](https://github.com/zendesk/copenhagen_theme/compare/v4.44.0...v4.44.1) (2026-07-03)
+
+
+### Bug Fixes
+
+* add styling to wrap long names in request page ([2e2ac5c](https://github.com/zendesk/copenhagen_theme/commit/2e2ac5cdee76cecd0c5a65a1d3f2f831b5fdb0e6))
+
 # [4.44.0](https://github.com/zendesk/copenhagen_theme/compare/v4.43.0...v4.44.0) (2026-06-30)
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "4.44.0",
+  "version": "4.44.1",
   "api_version": 4,
   "default_locale": "en-us",
   "settings": [

--- a/style.css
+++ b/style.css
@@ -3556,6 +3556,7 @@ ul {
   line-break: strict;
   color: lighten($text_color, 20%);
   width: 40%;
+  overflow-wrap: break-word;
 }
 .request-details .request-collaborators {
   display: inline-block;

--- a/styles/_request.scss
+++ b/styles/_request.scss
@@ -157,6 +157,7 @@
       line-break: strict;
       color: $secondary-text-color;
       width: 40%;
+      overflow-wrap: break-word;
     }
 
     .request-collaborators {


### PR DESCRIPTION
This pull request addresses a bug where long names were not wrapping properly on the request page. The update adds CSS styling to ensure long names are wrapped, improving the page's readability and layout. The version is also bumped to `4.44.1` to reflect this fix.

Bug Fix:

* Added `overflow-wrap: break-word;` to the relevant CSS selectors in both `style.css` and `styles/_request.scss` to ensure long names wrap correctly on the request page. [[1]](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aR3559) [[2]](diffhunk://#diff-c0941dbcfb62c4a89870795f62d1cd9a635612387c3a6268185f45453a8c486eR160)

Documentation and Versioning:

* Updated `CHANGELOG.md` with a new entry for version `4.44.1`, describing the bug fix.
* Bumped the theme version from `4.44.0` to `4.44.1` in `manifest.json`.