### PR TITLE
refactor(home): use native Zendesk instant search in the hero

### DIFF
--- a/style.css
+++ b/style.css
@@ -5334,7 +5334,10 @@ html body .header .search-wrapper {
   text-align: center;
 }
 
-/* Hero search bar */
+/* Hero search bar — the native {{search}} form is skinned into the pink
+   pill (same approach as .svc-search-pill on the results page). Zendesk's
+   platform renders and styles the real-time instant-search dropdown, so we
+   only style the input row here. */
 .svc-hero-search {
   position: relative;
   display: flex;
@@ -5345,6 +5348,10 @@ html body .header .search-wrapper {
   background: #fff;
   border-radius: 1000px;
   border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.svc-hero-search:focus-within {
+  border-color: var(--svc-navy);
 }
 
 .svc-hero-search-icon {
@@ -5358,20 +5365,43 @@ html body .header .search-wrapper {
   height: 24px;
 }
 
-.svc-hero-input {
-  flex: 1;
-  min-width: 0;
-  border: none;
-  outline: none;
-  background: transparent;
+/* Native search form + input, flattened to blend into the pill. */
+.svc-hero-search .search,
+.svc-hero-search form[role=search] {
+  flex: 1 1 auto !important;
+  min-width: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  border-radius: 0 !important;
+  display: flex !important;
+  align-items: center !important;
+}
+
+.svc-hero-search input[type=search] {
+  flex: 1 1 auto !important;
+  width: 100% !important;
+  height: auto !important;
+  border: none !important;
+  outline: none !important;
+  background: transparent !important;
   font-family: var(--svc-font);
   font-size: 18px;
   color: var(--svc-ink);
-  padding: 13px 16px;
+  padding: 13px 16px !important;
+  box-shadow: none !important;
 }
 
-.svc-hero-input::placeholder {
+.svc-hero-search input[type=search]::placeholder {
   color: #9aa1ad;
+}
+
+/* Zendesk adds its own magnifier + clear button; we supply our own icons. */
+.svc-hero-search .search-icon,
+.svc-hero-search .clear-button {
+  display: none !important;
 }
 
 .svc-hero-search-btn {
@@ -5399,161 +5429,6 @@ html body .header .search-wrapper {
   filter: brightness(1.08);
 }
 
-/* Live results dropdown */
-.svc-hero-results {
-  position: fixed;
-  z-index: 99999;
-  max-height: 70vh;
-  overflow-x: hidden;
-  overflow-y: auto;
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid var(--svc-line);
-  text-align: left;
-}
-
-.svc-res-group-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 12px 18px 6px;
-  border-bottom: 0.5px solid var(--svc-line);
-}
-
-.svc-res-group-header.svc-res-docs {
-  border-top: 0.5px solid var(--svc-line);
-  background: #fcfcfd;
-}
-
-.svc-res-group-title {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.6px;
-  text-transform: uppercase;
-}
-
-.svc-res-services .svc-res-group-title {
-  color: var(--svc-navy);
-}
-
-.svc-res-docs .svc-res-group-title {
-  color: var(--svc-gray);
-}
-
-.svc-res-group-count {
-  font-size: 11px;
-  color: #9aa1ad;
-}
-
-.svc-res-item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 11px 18px;
-  text-decoration: none;
-  cursor: pointer;
-  transition: background-color 0.14s ease;
-}
-
-.svc-res-item:hover, .svc-res-item.svc-res-active {
-  background: #f5f8ff;
-}
-
-.svc-res-item.svc-res-service {
-  border-left: 3px solid var(--svc-navy);
-}
-
-.svc-res-item.svc-res-doc {
-  border-left: 3px solid #c9ced8;
-}
-
-.svc-res-icon {
-  width: 34px;
-  height: 34px;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
-}
-
-.svc-res-service .svc-res-icon {
-  background: var(--svc-tint);
-  color: var(--svc-navy);
-}
-
-.svc-res-doc .svc-res-icon {
-  background: #f1f3f7;
-  color: var(--svc-gray);
-}
-
-.svc-res-icon svg {
-  width: 18px;
-  height: 18px;
-}
-
-.svc-res-text {
-  flex: 1;
-  min-width: 0;
-}
-
-.svc-res-title, .svc-res-sub {
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.svc-res-title {
-  font-size: 14px;
-  color: var(--svc-ink);
-}
-
-.svc-res-sub {
-  font-size: 12px;
-  color: var(--svc-gray-soft);
-}
-
-.svc-res-badge {
-  flex-shrink: 0;
-  font-size: 10.5px;
-  font-weight: 600;
-  padding: 3px 9px;
-  border-radius: 1000px;
-}
-
-.svc-res-service .svc-res-badge {
-  color: var(--svc-navy);
-  background: var(--svc-tint);
-}
-
-.svc-res-doc .svc-res-badge {
-  color: var(--svc-gray);
-  background: var(--svc-line);
-}
-
-.svc-res-empty, .svc-res-loading {
-  padding: 18px;
-  font-size: 13px;
-  color: var(--svc-gray-soft);
-  text-align: center;
-}
-
-.svc-res-footer {
-  display: block;
-  padding: 11px 18px;
-  border-top: 0.5px solid var(--svc-line);
-  font-size: 12.5px;
-  font-weight: 500;
-  color: var(--svc-navy);
-  text-align: center;
-  text-decoration: none;
-}
-
-.svc-res-footer:hover {
-  background: #f5f8ff;
-}
-
 /* Hero chips */
 .svc-hero-chips {
   display: flex;
@@ -5571,9 +5446,12 @@ html body .header .search-wrapper {
 }
 
 .svc-hero-chip {
+  display: inline-flex;
+  align-items: center;
   font-family: var(--svc-font);
   font-size: 12.5px;
   color: #fff;
+  text-decoration: none;
   cursor: pointer;
   padding: 5px 12px;
   border-radius: 1000px;
@@ -5585,6 +5463,7 @@ html body .header .search-wrapper {
 .svc-hero-chip:hover {
   background: rgba(255, 255, 255, 0.22);
   border-color: rgba(255, 255, 255, 0.45);
+  text-decoration: none;
 }
 
 /* ---------- CATALOG CARD ---------- */
@@ -6008,9 +5887,9 @@ a.svc-help-btn:hover,
     margin-top: 18px;
     padding: 6px 6px 6px 18px;
   }
-  .svc-hero-input {
-    font-size: 16px;
-    padding: 11px 12px;
+  .svc-hero-search input[type=search] {
+    font-size: 16px !important;
+    padding: 11px 12px !important;
   }
   .svc-hero-search-btn {
     width: 42px;

--- a/styles/_svc-home.scss
+++ b/styles/_svc-home.scss
@@ -89,7 +89,10 @@
   text-align: center;
 }
 
-/* Hero search bar */
+/* Hero search bar — the native {{search}} form is skinned into the pink
+   pill (same approach as .svc-search-pill on the results page). Zendesk's
+   platform renders and styles the real-time instant-search dropdown, so we
+   only style the input row here. */
 .svc-hero-search {
   position: relative;
   display: flex;
@@ -101,20 +104,42 @@
   border-radius: 1000px;
   border: 1px solid rgba(0, 0, 0, 0.08);
 }
+.svc-hero-search:focus-within { border-color: var(--svc-navy); }
 .svc-hero-search-icon { display: inline-flex; align-items: center; color: var(--svc-gray); }
 .svc-hero-search-icon svg { width: 24px; height: 24px; }
-.svc-hero-input {
-  flex: 1;
-  min-width: 0;
-  border: none;
-  outline: none;
-  background: transparent;
+
+/* Native search form + input, flattened to blend into the pill. */
+.svc-hero-search .search,
+.svc-hero-search form[role="search"] {
+  flex: 1 1 auto !important;
+  min-width: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  border-radius: 0 !important;
+  display: flex !important;
+  align-items: center !important;
+}
+.svc-hero-search input[type="search"] {
+  flex: 1 1 auto !important;
+  width: 100% !important;
+  height: auto !important;
+  border: none !important;
+  outline: none !important;
+  background: transparent !important;
   font-family: var(--svc-font);
   font-size: 18px;
   color: var(--svc-ink);
-  padding: 13px 16px;
+  padding: 13px 16px !important;
+  box-shadow: none !important;
 }
-.svc-hero-input::placeholder { color: #9aa1ad; }
+.svc-hero-search input[type="search"]::placeholder { color: #9aa1ad; }
+/* Zendesk adds its own magnifier + clear button; we supply our own icons. */
+.svc-hero-search .search-icon,
+.svc-hero-search .clear-button { display: none !important; }
+
 .svc-hero-search-btn {
   display: inline-flex;
   align-items: center;
@@ -133,83 +158,16 @@
 .svc-hero-search-btn svg { width: 20px; height: 20px; }
 .svc-hero-search-btn:hover { filter: brightness(1.08); }
 
-/* Live results dropdown */
-.svc-hero-results {
-  position: fixed;
-  z-index: 99999;
-  max-height: 70vh;
-  overflow-x: hidden;
-  overflow-y: auto;
-  background: #fff;
-  border-radius: 16px;
-  border: 1px solid var(--svc-line);
-  text-align: left;
-}
-.svc-res-group-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 12px 18px 6px;
-  border-bottom: 0.5px solid var(--svc-line);
-}
-.svc-res-group-header.svc-res-docs { border-top: 0.5px solid var(--svc-line); background: #fcfcfd; }
-.svc-res-group-title { font-size: 11px; font-weight: 600; letter-spacing: 0.6px; text-transform: uppercase; }
-.svc-res-services .svc-res-group-title { color: var(--svc-navy); }
-.svc-res-docs .svc-res-group-title { color: var(--svc-gray); }
-.svc-res-group-count { font-size: 11px; color: #9aa1ad; }
-.svc-res-item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 11px 18px;
-  text-decoration: none;
-  cursor: pointer;
-  transition: background-color 0.14s ease;
-}
-.svc-res-item:hover, .svc-res-item.svc-res-active { background: #f5f8ff; }
-.svc-res-item.svc-res-service { border-left: 3px solid var(--svc-navy); }
-.svc-res-item.svc-res-doc { border-left: 3px solid #c9ced8; }
-.svc-res-icon {
-  width: 34px; height: 34px;
-  flex-shrink: 0;
-  display: flex; align-items: center; justify-content: center;
-  border-radius: 8px;
-}
-.svc-res-service .svc-res-icon { background: var(--svc-tint); color: var(--svc-navy); }
-.svc-res-doc .svc-res-icon { background: #f1f3f7; color: var(--svc-gray); }
-.svc-res-icon svg { width: 18px; height: 18px; }
-.svc-res-text { flex: 1; min-width: 0; }
-.svc-res-title, .svc-res-sub {
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.svc-res-title { font-size: 14px; color: var(--svc-ink); }
-.svc-res-sub { font-size: 12px; color: var(--svc-gray-soft); }
-.svc-res-badge { flex-shrink: 0; font-size: 10.5px; font-weight: 600; padding: 3px 9px; border-radius: 1000px; }
-.svc-res-service .svc-res-badge { color: var(--svc-navy); background: var(--svc-tint); }
-.svc-res-doc .svc-res-badge { color: var(--svc-gray); background: var(--svc-line); }
-.svc-res-empty, .svc-res-loading { padding: 18px; font-size: 13px; color: var(--svc-gray-soft); text-align: center; }
-.svc-res-footer {
-  display: block;
-  padding: 11px 18px;
-  border-top: 0.5px solid var(--svc-line);
-  font-size: 12.5px;
-  font-weight: 500;
-  color: var(--svc-navy);
-  text-align: center;
-  text-decoration: none;
-}
-.svc-res-footer:hover { background: #f5f8ff; }
-
 /* Hero chips */
 .svc-hero-chips { display: flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: wrap; margin-top: 14px; }
 .svc-hero-chips-label { font-family: var(--svc-font); font-size: 12.5px; color: rgba(255, 255, 255, 0.6); }
 .svc-hero-chip {
+  display: inline-flex;
+  align-items: center;
   font-family: var(--svc-font);
   font-size: 12.5px;
   color: #fff;
+  text-decoration: none;
   cursor: pointer;
   padding: 5px 12px;
   border-radius: 1000px;
@@ -217,7 +175,7 @@
   border: 1px solid rgba(255, 255, 255, 0.18);
   transition: background-color 0.18s ease, border-color 0.18s ease;
 }
-.svc-hero-chip:hover { background: rgba(255, 255, 255, 0.22); border-color: rgba(255, 255, 255, 0.45); }
+.svc-hero-chip:hover { background: rgba(255, 255, 255, 0.22); border-color: rgba(255, 255, 255, 0.45); text-decoration: none; }
 
 /* ---------- CATALOG CARD ---------- */
 .svc-cardwrap {
@@ -499,7 +457,7 @@ a.svc-help-btn:hover,
   .svc-hero-title { font-size: clamp(24px, 7vw, 32px); }
   .svc-hero-subtitle { font-size: 14px; margin-top: 8px; }
   .svc-hero-search { margin-top: 18px; padding: 6px 6px 6px 18px; }
-  .svc-hero-input { font-size: 16px; padding: 11px 12px; }
+  .svc-hero-search input[type="search"] { font-size: 16px !important; padding: 11px 12px !important; }
   .svc-hero-search-btn { width: 42px; height: 42px; }
 
   .svc-cardwrap { padding: 18px 10px 40px; max-width: 100%; overflow-x: hidden; }

--- a/templates/service_list_page.hbs
+++ b/templates/service_list_page.hbs
@@ -31,30 +31,33 @@
       <h2 class="svc-hero-title"><span id="svc-list-greeting">&nbsp;</span><span id="svc-list-greeting-name" class="svc-greeting-name"></span></h2>
       <p class="svc-hero-subtitle" id="svc-list-subtitle">What do you need help with today?</p>
 
-      <form class="svc-hero-search" id="svc-hero-search" role="search" autocomplete="off">
-        <i class="svc-hero-search-icon" aria-hidden="true">
+      {{!-- Native Zendesk instant search (articles), skinned into the hero
+            pill. Real-time suggestions and the results page are rendered by
+            the platform — there is no custom fetch/scoring layer. The left
+            icon is decorative; the pink button submits the native form (wired
+            in the script below). Styling lives in styles/_svc-home.scss. --}}
+      <h2 class="visibility-hidden">{{ t 'search' }}</h2>
+      <div class="svc-hero-search" id="svc-hero-search">
+        <span class="svc-hero-search-icon" aria-hidden="true">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
           </svg>
-        </i>
-        <input type="text" id="svc-hero-input" class="svc-hero-input"
-               placeholder="How can we help?" aria-label="{{t 'search'}}"
-               role="combobox" aria-expanded="false" aria-controls="svc-hero-results" aria-autocomplete="list" />
-        <button type="submit" class="svc-hero-search-btn" aria-label="{{t 'search'}}">
+        </span>
+        {{search submit=false instant=settings.instant_search class='search search-full'}}
+        <button type="button" class="svc-hero-search-btn" id="svc-hero-search-btn" aria-label="{{t 'search'}}">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
           </svg>
         </button>
-        <div class="svc-hero-results" id="svc-hero-results" role="listbox" aria-label="Search results" hidden></div>
-      </form>
+      </div>
 
       <div class="svc-hero-chips" id="svc-hero-chips">
         <span class="svc-hero-chips-label">Popular:</span>
-        <button type="button" class="svc-hero-chip" data-q="PIV certificate renewal">PIV Cert Renewal</button>
-        <button type="button" class="svc-hero-chip" data-q="lost stolen device">Lost/Stolen Device</button>
-        <button type="button" class="svc-hero-chip" data-q="lost stolen PIV card">Lost/Stolen PIV Card</button>
-        <button type="button" class="svc-hero-chip" data-q="external sharepoint">SharePoint</button>
-        <button type="button" class="svc-hero-chip" data-q="shared mailbox distribution list">Shared Mailboxes/Distribution Lists</button>
+        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=PIV%20certificate%20renewal">PIV Cert Renewal</a>
+        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=lost%20stolen%20device">Lost/Stolen Device</a>
+        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=lost%20stolen%20PIV%20card">Lost/Stolen PIV Card</a>
+        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=external%20sharepoint">SharePoint</a>
+        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=shared%20mailbox%20distribution%20list">Shared Mailboxes/Distribution Lists</a>
       </div>
     </div>
     {{/if}}
@@ -213,253 +216,27 @@
   })();
 </script>
 
-<!-- Combined live search: services (catalog API) + resources (articles API) -->
+<!-- Native instant-search wiring: submit the native {{search}} form when the
+     pink button is clicked, and keep the ARPA-H placeholder text. The
+     real-time article suggestions and the results page are provided by
+     Zendesk's platform — there is no custom fetch/scoring layer. -->
 <script>
   (function () {
-    const form    = document.getElementById('svc-hero-search');
-    const input   = document.getElementById('svc-hero-input');
-    const chips   = document.getElementById('svc-hero-chips');
-    const results = document.getElementById('svc-hero-results');
-    if (!form || !input || !results) return;
+    var wrap = document.getElementById('svc-hero-search');
+    if (!wrap) return;
+    var form  = wrap.querySelector('form[role="search"]');
+    var input = wrap.querySelector('input[type="search"]');
+    var btn   = document.getElementById('svc-hero-search-btn');
 
-    const HC_BASE = (location.pathname.match(/^\/hc\/[^/]+/) || ['/hc/en-us'])[0];
-    const SERVICES_URL = HC_BASE + '/services';
-    const SEARCH_PAGE  = HC_BASE + '/search?query=';
-    const MAX = 5;
-    let timer = null, token = 0;
+    if (input) input.setAttribute('placeholder', 'How can we help?');
 
-    const SYNONYMS = {
-      laptop:   ['device', 'computer', 'macbook', 'hardware', 'equipment'],
-      computer: ['device', 'laptop', 'hardware', 'equipment'],
-      monitor:  ['device', 'peripheral', 'hardware', 'display'],
-      keyboard: ['device', 'peripheral', 'hardware'],
-      mouse:    ['device', 'peripheral', 'hardware'],
-      wifi:     ['network', 'internet', 'wireless', 'connection'],
-      internet: ['network', 'wifi', 'connection'],
-      vpn:      ['network', 'remote', 'access', 'connection'],
-      email:    ['outlook', 'mailbox', 'mail'],
-      phone:    ['mobile', 'cell', 'device', 'telephone'],
-      login:    ['account', 'password', 'access', 'sign in', 'credentials'],
-      signin:   ['account', 'password', 'access', 'login'],
-      printer:  ['print', 'peripheral', 'device']
-    };
-
-    if (results.parentElement !== document.body) document.body.appendChild(results);
-
-    const ICON_SERVICE = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="12" rx="2"></rect><line x1="2" y1="20" x2="22" y2="20"></line></svg>';
-    const ICON_DOC     = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg>';
-
-    const esc = s => String(s == null ? '' : s)
-      .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
-      .replace(/"/g,'&quot;').replace(/'/g,'&#39;');
-    const stripTags = s => { const d = document.createElement('div'); d.innerHTML = s || ''; return (d.textContent || '').trim(); };
-
-    function fetchJSON(url, tok) {
-      return fetch(url, { headers: { Accept: 'application/json' }, credentials: 'same-origin' })
-        .then(r => r.ok ? r.json() : null)
-        .then(d => tok === token ? d : null)
-        .catch(() => null);
-    }
-
-    let allServices = null;
-    let servicesLoading = null;
-
-    /* Cache the fetched catalog in sessionStorage so it loads once per session
-       (TTL 30 min) instead of on every page load. Shared with the item page. */
-    const SVC_CACHE_KEY = 'svcCatalogItems';
-    const SVC_CACHE_TTL = 30 * 60 * 1000;
-    function svcReadCache() {
-      try {
-        const c = JSON.parse(sessionStorage.getItem(SVC_CACHE_KEY) || 'null');
-        if (!c || !Array.isArray(c.items) || (Date.now() - c.ts) > SVC_CACHE_TTL) return null;
-        return c.items;
-      } catch (e) { return null; }
-    }
-    function svcWriteCache(items) {
-      try { sessionStorage.setItem(SVC_CACHE_KEY, JSON.stringify({ ts: Date.now(), items: items })); } catch (e) {}
-    }
-
-    function normalizeItem(it) {
-      const id = it.id || it.uuid || '';
-      return {
-        title: stripTags(it.name || it.title || 'Service'),
-        desc:  stripTags(it.description || ''),
-        category: stripTags(it.category_name || (it.category && it.category.name) || ''),
-        href:  it.html_url || (id ? HC_BASE + '/services/' + id : SERVICES_URL)
-      };
-    }
-
-    function loadAllServices() {
-      if (allServices) return Promise.resolve(allServices);
-      if (servicesLoading) return servicesLoading;
-
-      const cached = svcReadCache();
-      if (cached) { allServices = cached; return Promise.resolve(cached); }
-
-      servicesLoading = (async () => {
-        const out = [];
-        let url = '/api/v2/help_center/service_catalog/items.json?page[size]=100';
-        let guard = 0;
-        while (url && guard < 20) {
-          guard++;
-          let data;
-          try {
-            const r = await fetch(url, { headers: { Accept: 'application/json' }, credentials: 'same-origin' });
-            if (!r.ok) break;
-            data = await r.json();
-          } catch (e) { break; }
-          const arr = data.service_catalog_items || data.items || data.results || data.records || [];
-          arr.forEach(it => out.push(normalizeItem(it)));
-          url = (data.meta && data.meta.has_more && data.links && data.links.next) ? data.links.next : null;
-        }
-        allServices = out;
-        svcWriteCache(out);
-        return out;
-      })();
-
-      return servicesLoading;
-    }
-
-    function scoreService(svc, terms) {
-      const title = svc.title.toLowerCase();
-      const desc  = svc.desc.toLowerCase();
-      const cat   = svc.category.toLowerCase();
-      let score = 0;
-      for (const t of terms) {
-        if (!t) continue;
-        if (title === t) score += 100;
-        else if (title.startsWith(t)) score += 50;
-        else if (title.indexOf(t) !== -1) score += 30;
-        if (desc.indexOf(t) !== -1) score += 10;
-        if (cat.indexOf(t) !== -1) score += 15;
-      }
-      return score;
-    }
-
-    function buildTerms(q) {
-      const base = q.toLowerCase().split(/\s+/).filter(Boolean);
-      const terms = new Set(base);
-      base.forEach(w => {
-        const key = w.replace(/[^a-z]/g, '');
-        (SYNONYMS[key] || []).forEach(s => terms.add(s.toLowerCase()));
-      });
-      return { primary: base, all: Array.from(terms) };
-    }
-
-    function getServices(q) {
-      return loadAllServices().then(list => {
-        if (!list || !list.length) return [];
-        const { primary, all } = buildTerms(q);
-
-        let scored = list
-          .map(svc => ({ svc, score: scoreService(svc, primary) }))
-          .filter(x => x.score > 0);
-
-        if (scored.length < 3 && all.length > primary.length) {
-          const have = new Set(scored.map(x => x.svc.href));
-          list.forEach(svc => {
-            if (have.has(svc.href)) return;
-            const s = scoreService(svc, all);
-            if (s > 0) scored.push({ svc, score: s - 5 });
-          });
-        }
-
-        scored.sort((a, b) => b.score - a.score);
-        return scored.slice(0, MAX).map(x => ({
-          title: x.svc.title,
-          href: x.svc.href,
-          sub: x.svc.category || (x.svc.desc ? x.svc.desc.slice(0, 70) : 'Service catalog')
-        }));
+    if (btn && form) {
+      btn.addEventListener('click', function () {
+        if (input && !input.value.trim()) { input.focus(); return; }
+        if (typeof form.requestSubmit === 'function') form.requestSubmit();
+        else form.submit();
       });
     }
-
-    function getDocs(q, tok) {
-      const url = '/api/v2/help_center/articles/search.json?per_page=' + MAX + '&query=' + encodeURIComponent(q);
-      return fetchJSON(url, tok).then(d => {
-        if (!d) return [];
-        return (d.results || []).slice(0, MAX).map(a => ({
-          title: stripTags(a.title) || 'Untitled',
-          href: a.html_url || (SEARCH_PAGE + encodeURIComponent(q)),
-          sub: a.snippet ? stripTags(a.snippet).slice(0, 70) : 'Knowledge article'
-        }));
-      });
-    }
-
-    function group(title, cls, badge, icon, items) {
-      if (!items.length) return '';
-      const itemCls = cls === 'svc-res-services' ? 'svc-res-service' : 'svc-res-doc';
-      let html = '<div class="svc-res-group-header ' + cls + '">' +
-        '<span class="svc-res-group-title">' + esc(title) + '</span>' +
-        '<span class="svc-res-group-count">' + items.length + '</span></div>';
-      for (const it of items) {
-        html += '<a class="svc-res-item ' + itemCls + '" role="option" href="' + esc(it.href) + '">' +
-          '<span class="svc-res-icon" aria-hidden="true">' + icon + '</span>' +
-          '<span class="svc-res-text"><span class="svc-res-title">' + esc(it.title) + '</span>' +
-          '<span class="svc-res-sub">' + esc(it.sub) + '</span></span>' +
-          '<span class="svc-res-badge">' + badge + '</span></a>';
-      }
-      return html;
-    }
-
-    function place() {
-      const r = form.getBoundingClientRect();
-      const m = 12;
-      let w = Math.min(r.width, window.innerWidth - m * 2);
-      let l = Math.min(Math.max(r.left, m), window.innerWidth - m - w);
-      results.style.left  = Math.round(l) + 'px';
-      results.style.width = Math.round(w) + 'px';
-      results.style.top   = Math.round(r.bottom + 10) + 'px';
-    }
-    function show(html) { results.innerHTML = html; results.hidden = false; place(); input.setAttribute('aria-expanded', 'true'); }
-    function hide()     { results.hidden = true; results.innerHTML = ''; input.setAttribute('aria-expanded', 'false'); }
-
-    function run(q) {
-      q = (q || '').trim();
-      if (q.length < 2) { hide(); return; }
-      const tok = ++token;
-      show('<div class="svc-res-loading">Searching…</div>');
-      Promise.all([getServices(q), getDocs(q, tok)]).then(([services, docs]) => {
-        if (tok !== token) return;
-        let html =
-          group('Recommended services', 'svc-res-services', 'Service', ICON_SERVICE, services) +
-          group('Self-Help Resources', 'svc-res-docs', 'Resource', ICON_DOC, docs);
-        if (!services.length && !docs.length) html = '<div class="svc-res-empty">No matching services or resources.</div>';
-        html += '<a class="svc-res-footer" href="' + SEARCH_PAGE + encodeURIComponent(q) + '">See all results for &ldquo;' + esc(q) + '&rdquo;</a>';
-        show(html);
-      });
-    }
-
-    loadAllServices();
-
-    input.addEventListener('input', () => { clearTimeout(timer); const q = input.value; timer = setTimeout(() => run(q), 220); });
-    input.addEventListener('focus', () => { if (input.value.trim().length >= 2 && results.innerHTML) { results.hidden = false; place(); } });
-    form.addEventListener('submit', e => { e.preventDefault(); const q = input.value.trim(); if (q) window.location.href = SEARCH_PAGE + encodeURIComponent(q); });
-
-    if (chips) chips.addEventListener('click', e => {
-      const chip = e.target.closest && e.target.closest('.svc-hero-chip');
-      if (!chip) return;
-      const q = chip.getAttribute('data-q') || chip.textContent.trim();
-      input.value = q; input.focus(); run(q);
-    });
-
-    input.addEventListener('keydown', e => {
-      if (results.hidden) return;
-      const items = Array.from(results.querySelectorAll('.svc-res-item'));
-      if (!items.length) return;
-      let i = items.findIndex(el => el.classList.contains('svc-res-active'));
-      if (e.key === 'ArrowDown')      { e.preventDefault(); i = (i + 1) % items.length; }
-      else if (e.key === 'ArrowUp')   { e.preventDefault(); i = (i - 1 + items.length) % items.length; }
-      else if (e.key === 'Enter' && i >= 0) { e.preventDefault(); window.location.href = items[i].getAttribute('href'); return; }
-      else if (e.key === 'Escape')    { hide(); return; }
-      else return;
-      items.forEach(el => el.classList.remove('svc-res-active'));
-      items[i].classList.add('svc-res-active');
-      items[i].scrollIntoView({ block: 'nearest' });
-    });
-
-    document.addEventListener('click', e => { if (!form.contains(e.target) && !results.contains(e.target)) hide(); });
-    window.addEventListener('scroll', () => { if (!results.hidden) place(); }, { passive: true });
-    window.addEventListener('resize', () => { if (!results.hidden) place(); });
   })();
 </script>
 


### PR DESCRIPTION
Replace the custom fetch-based live-search widget on the home page (service_list_page) with Zendesk's native {{search instant=...}} helper, skinned into the existing hero pill — the same non-diverging approach already used on search_results.hbs.

- Swap the custom combobox + ~165-line fetch/scoring/dropdown script for {{search submit=false instant=settings.instant_search class='search search-full'}}. Real-time article suggestions and the results page are now rendered by the platform (no /api/v2 catalog crawl, no synonyms map, no portalled dropdown).

- Preserve the look and feel: pink pill, left icon, pink submit button (wired to submit the native form), greeting, and 'Popular:' chips (now native search links).

- Reskin the native input in _svc-home.scss and drop the dead custom dropdown CSS (.svc-hero-results / .svc-res-*). Regenerated style.css; no src/ changes.

Tradeoff: real-time results are articles-only (native) rather than the custom blend of services + articles.

## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->