### PR TITLE
fix(service-catalog): restore via.channel on request submission

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.spec.tsx
@@ -108,6 +108,12 @@ describe("submitServiceItemRequest", () => {
       { id: 1, value: "value-1" },
       { id: associatedLookupField.id, value: mockItem.id },
     ]);
+    // Guards against a regression where the request submitted through the
+    // `/hc/api/v2/service_catalog/requests` proxy loses its "web form"
+    // channel signal and falls out of channel-based omni-channel routing
+    // (unlike a native <form> submission, this endpoint has no implicit
+    // channel signal, so it must be set explicitly).
+    expect(request.via).toEqual({ channel: "web form", source: 50 });
   });
 
   it("does not send requester_id or collaborators for a self request", async () => {

--- a/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.tsx
@@ -71,6 +71,10 @@ export async function submitServiceItemRequest(
             uploads: uploadTokens,
           },
           custom_fields: [...customFields, ...lookupFields],
+          via: {
+            channel: "web form",
+            source: 50,
+          },
           ...(isRequestingOnBehalf
             ? { requester_id: requesterId, collaborators: [submitterId] }
             : {}),


### PR DESCRIPTION
## Problem

`submitServiceItemRequest` posts to `/hc/api/v2/service_catalog/requests` via `fetch()` (an AJAX JSON POST). Unlike a native `<form>` submission — which Zendesk's backend automatically tags `via.channel = "web form"` — this endpoint has no implicit channel signal.

Upstream `zendesk/copenhagen_theme` PR [#825](https://github.com/zendesk/copenhagen_theme/pull/825) migrated Service Catalog request submission to this endpoint and, in the same diff hunk, silently dropped the request body's explicit:

```ts
via: {
  channel: "web form",
  source: 50,
},
```

That PR's description is entirely about request-on-behalf/`requester_id`/`collaborators` logic and never mentions this change — it looks like an unintentional side effect of the endpoint switch, not a deliberate decision.

## Impact (confirmed in this account)

Without the explicit `via` block, requests land with `via.channel` set by the proxy's own default classification (observed as `"help_center"`) instead of `"web form"`. That breaks channel-based omni-channel routing rules — affected tickets are never assigned and stay `status: new` indefinitely.

Confirmed by comparing two otherwise-identical real tickets in this account, submitted just before/after the endpoint migration landed:
- Pre-migration: `via.channel = "web"`, matched the routing rule, assigned, `status: open`.
- Post-migration: `via.channel = "help_center"`, didn't match, never assigned, stuck at `status: new`.

Everything else about the two tickets (form, brand, group, org, requester, tags) was identical.

## Fix

Re-adds the `via: { channel: "web form", source: 50 }` block, restoring pre-migration behavior. Minimal, additive diff.

## Upstream

Also filed the same fix upstream: [zendesk/copenhagen_theme#847](https://github.com/zendesk/copenhagen_theme/pull/847) (flagged there as needing maintainer verification, since it's an internal/undocumented Zendesk proxy endpoint and I can't confirm from static code review whether it actually honors a client-supplied `via`). Applying the fix here directly as well rather than waiting on that review cycle, since our Guide instance is live now and this is actively breaking ticket routing.

## Testing

- Added an assertion in `submitServiceItemRequest.spec.tsx` guarding the `via` block is present in the submitted request body.
- `yarn jest src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.spec.tsx` — 6/6 pass.
- `yarn jest src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx` — 17/17 pass (sibling suite that mocks this function).
- `yarn eslint src` — 0 errors (pre-existing warnings unrelated).
- `NODE_ENV=production yarn rollup -c` — clean build.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>