### PR TITLE
fix(theme): address Copenhagen theme standards divergences vs upstream

### DIFF
--- a/script.js
+++ b/script.js
@@ -754,6 +754,50 @@
     }
   })();
 
+  // ---------------------------------------------------------------------------
+  // 3. Wire the pink search-pill button (templates/search_results.hbs) to
+  //    submit the native search, matching native <button type="submit"> behavior.
+  //    Previously an inline <script> in that template; moved here per the
+  //    "don't re-add inline scripts" rule documented in document_head.hbs.
+  // ---------------------------------------------------------------------------
+  (function () {
+    function wireSearchPillButton() {
+      var btn = document.getElementById("svc-search-pill-btn");
+      if (!btn || btn.dataset.svcWired === "1") return;
+      var pill = btn.closest(".svc-search-pill");
+      if (!pill) return;
+      btn.dataset.svcWired = "1";
+      btn.addEventListener("click", function () {
+        var input = pill.querySelector(
+          'input[type="search"], input[type="text"], input:not([type])'
+        );
+        if (!input) return;
+        var form = input.form || input.closest("form");
+        if (form) {
+          if (typeof form.requestSubmit === "function") form.requestSubmit();
+          else form.submit();
+        } else {
+          input.focus();
+          input.dispatchEvent(
+            new KeyboardEvent("keydown", {
+              key: "Enter",
+              code: "Enter",
+              keyCode: 13,
+              which: 13,
+              bubbles: true,
+            })
+          );
+        }
+      });
+    }
+
+    if (document.readyState !== "loading") {
+      wireSearchPillButton();
+    } else {
+      document.addEventListener("DOMContentLoaded", wireSearchPillButton);
+    }
+  })();
+
   /*
    * Shared "live search" widget logic for the Service Catalog mini search
    * (service_page.hbs) and hero search (service_list_page.hbs).
@@ -1339,5 +1383,459 @@
     window.initSvcSearch = initSvcSearch;
     window.svcSafeHref = safeHref;
   }
+
+  /*
+   * Shared "who is this user" name-resolution helper for the service-catalog
+   * personalized greetings.
+   *
+   * Previously this fetch + alias/first-name parsing logic was copy-pasted
+   * almost line-for-line inline in both templates/service_page.hbs and
+   * templates/service_list_page.hbs (one ES5, one ES6, otherwise identical).
+   * Centralized here — same rationale as src/svcSearch.js, which already
+   * consolidated the duplicated search widget logic out of these same two
+   * templates.
+   *
+   * Each page still composes its own greeting text/reveal-timing around the
+   * resolved name (that part genuinely differs per page), so this module only
+   * owns the "fetch the signed-in user and pick a real display name" part.
+   *
+   * ES2015 only — this file is bundled into script.js.
+   */
+
+  function looksLikeAlias(v) {
+    if (!v) return true;
+    var s = String(v).trim();
+    if (!s) return true;
+    if (s.indexOf("@") !== -1) return true;
+    if (/^[a-z0-9._-]+$/.test(s) && s.indexOf(" ") === -1) return true;
+    return false;
+  }
+
+  function firstNameOf(name) {
+    var s = String(name || "").trim();
+    if (!s) return "";
+    if (s.indexOf(",") !== -1) {
+      var parts = s
+        .split(",")
+        .map(function (p) {
+          return p.trim();
+        })
+        .filter(Boolean);
+      if (parts.length >= 2) return parts[1].split(/\s+/)[0];
+    }
+    return s.split(/\s+/)[0];
+  }
+
+  // Fetches the signed-in user and calls back with their resolved first name
+  // (or "" if unavailable/anonymous/alias-only). Never rejects — network or
+  // parsing failures resolve to "" so callers don't need their own try/catch.
+  window.svcFetchFirstName = function (callback) {
+    fetch("/api/v2/users/me.json", {
+      headers: { Accept: "application/json" },
+      credentials: "same-origin",
+    })
+      .then(function (r) {
+        return r.ok ? r.json() : null;
+      })
+      .then(function (d) {
+        var u = d && d.user;
+        if (!u) {
+          callback("");
+          return;
+        }
+        var candidates = [
+          u.name,
+          u.details && u.details.name,
+          u.user_fields &&
+            (u.user_fields.full_name ||
+              u.user_fields.preferred_name ||
+              u.user_fields.first_name),
+        ];
+        var realName =
+          candidates.find(function (c) {
+            return !looksLikeAlias(c);
+          }) || u.name;
+        callback(firstNameOf(realName));
+      })
+      .catch(function () {
+        callback("");
+      });
+  };
+
+  /*
+   * Shared "reveal once the async content is ready" controller for the
+   * service-catalog skeleton placeholders.
+   *
+   * Previously this MutationObserver + settle-timer + hard-timeout + bfcache
+   * pattern was duplicated (with only the completion check and target/skeleton
+   * ids differing) between templates/service_page.hbs (form skeleton) and
+   * templates/service_list_page.hbs (catalog skeleton). Centralized here so
+   * both pages configure the same controller instead of re-implementing it.
+   *
+   * ES2015 only — this file is bundled into script.js.
+   */
+
+  // options:
+  //   targetId       (required) id of the element to observe for completion
+  //   skeletonId     (optional) id of the skeleton placeholder to hide/remove
+  //   readyClasses   (optional) array of classes added to <html> once revealed
+  //   isComplete(el) (required) returns true once `el` has its real content
+  //   settleMs       (optional, default 400) debounce after isComplete() first
+  //                  passes, so we don't reveal mid-render
+  //   hardCapMs      (optional, default 6000) reveal unconditionally by this
+  //                  point even if isComplete() never returns true
+  //   onReveal()     (optional) extra callback once revealed
+  window.initSvcRevealOnComplete = function (options) {
+    var root = document.documentElement;
+    var target = document.getElementById(options.targetId);
+    if (!target) return;
+    var skel = options.skeletonId
+      ? document.getElementById(options.skeletonId)
+      : null;
+
+    var done = false;
+    function reveal() {
+      if (done) return;
+      done = true;
+      (options.readyClasses || []).forEach(function (c) {
+        root.classList.add(c);
+      });
+      if (skel) {
+        skel.classList.add(options.skeletonHideClass || "svc-skel-hide");
+        setTimeout(function () {
+          if (skel && skel.parentNode) skel.parentNode.removeChild(skel);
+        }, 320);
+      }
+      if (options.onReveal) options.onReveal();
+    }
+
+    var settleTimer = null;
+    function armSettle() {
+      if (settleTimer) clearTimeout(settleTimer);
+      settleTimer = setTimeout(reveal, options.settleMs || 400);
+    }
+    function check() {
+      if (!done && options.isComplete(target)) armSettle();
+    }
+
+    check();
+    var mo = new MutationObserver(check);
+    mo.observe(target, { childList: true, subtree: true });
+    (function stop() {
+      if (done) mo.disconnect();
+      else setTimeout(stop, 300);
+    })();
+
+    setTimeout(reveal, options.hardCapMs || 6000);
+
+    window.addEventListener("pageshow", function (e) {
+      if (e.persisted) reveal();
+    });
+  };
+
+  /*
+   * Service-catalog list-page enhancements that used to be two separate inline
+   * <script> blocks in templates/service_list_page.hbs ("Catalog enhancements"
+   * and "Category-swap skeleton hiding"). Neither depends on server-rendered
+   * Curlybars data, so — same rationale as src/domFixups.js — they belong here
+   * instead of inline in the template.
+   *
+   * Both sections no-op on any page without #service-catalog-main-content, so
+   * this file is safe to include globally (bundled into script.js for every
+   * page) rather than only on the service list page.
+   *
+   * ES2015 only — this file is bundled into script.js.
+   */
+
+  // ---------------------------------------------------------------------------
+  // 1. Tooltips for truncated card descriptions, category description text,
+  //    and removing the Zendesk service-catalog widget's own search field
+  //    (the page has its own hero search instead).
+  // ---------------------------------------------------------------------------
+  (function () {
+    const main = document.getElementById("service-catalog-main-content");
+    if (!main) return;
+
+    const safeClosest = (el, sel) =>
+      el && el.nodeType === 1 && typeof el.closest === "function"
+        ? el.closest(sel)
+        : null;
+    const inSidebar = (el) =>
+      !!safeClosest(el, '[data-test-id^="sidebar-category"]');
+
+    const tip = document.createElement("div");
+    tip.className = "svc-tooltip";
+    tip.setAttribute("role", "tooltip");
+    tip.style.left = "-9999px";
+    tip.style.top = "-9999px";
+    document.body.appendChild(tip);
+    let hideTimer = null;
+
+    function getCard(el) {
+      if (!el || el.nodeType !== 1) return null;
+      if (inSidebar(el)) return null;
+      const card =
+        safeClosest(el, 'a[href*="/services/"]') ||
+        safeClosest(el, '[data-testid="service-catalog-list-item-container"]');
+      if (!card || inSidebar(card)) return null;
+      if (
+        !safeClosest(card, 'a[href*="/services/"]') &&
+        !card.querySelector('a[href*="/services/"]')
+      )
+        return null;
+      return card;
+    }
+    function findDescEl(card) {
+      if (!card || inSidebar(card) || typeof card.querySelectorAll !== "function")
+        return null;
+      const leaves = Array.from(card.querySelectorAll("div, p, span")).filter(
+        (el) =>
+          el &&
+          !el.querySelector(
+            "a, h1, h2, h3, h4, h5, h6, svg, img, button, div, p, span"
+          ) &&
+          (el.textContent || "").trim().length > 0
+      );
+      if (leaves.length < 2) return null;
+      const heading = card.querySelector("h1,h2,h3,h4,h5,h6");
+      const titleText = heading
+        ? heading.textContent.trim()
+        : leaves[0].textContent.trim();
+      return (
+        leaves.find((l) => {
+          const t = l.textContent.trim();
+          return t && t !== titleText;
+        }) || null
+      );
+    }
+    function descText(card) {
+      const el = findDescEl(card);
+      if (!el) return "";
+      const t = el.textContent.trim();
+      if (/^\d+$/.test(t)) return "";
+      return t;
+    }
+
+    function hideDescriptions() {
+      main
+        .querySelectorAll(
+          'a[href*="/services/"], [class*="card"], [class*="Card"]'
+        )
+        .forEach((card) => {
+          if (inSidebar(card)) return;
+          const el = findDescEl(card);
+          if (el && !el.classList.contains("svc-desc-hidden"))
+            el.classList.add("svc-desc-hidden");
+        });
+    }
+    function positionTip(card) {
+      const rect = card.getBoundingClientRect();
+      tip.style.maxWidth = Math.max(180, Math.min(240, rect.width + 20)) + "px";
+      const t = tip.getBoundingClientRect(),
+        gap = 8;
+      let left = Math.min(
+        Math.max(rect.left, 12),
+        window.innerWidth - t.width - 12
+      );
+      tip.style.setProperty(
+        "--svc-arrow-left",
+        Math.max(
+          10,
+          Math.min(t.width - 18, rect.left + rect.width / 2 - left - 4)
+        ) + "px"
+      );
+      let top;
+      if (window.innerHeight - rect.bottom > t.height + gap + 12) {
+        top = rect.bottom + gap;
+        tip.classList.add("svc-tooltip-below");
+        tip.classList.remove("svc-tooltip-above");
+      } else {
+        top = rect.top - t.height - gap;
+        tip.classList.add("svc-tooltip-above");
+        tip.classList.remove("svc-tooltip-below");
+      }
+      tip.style.left = Math.round(left) + "px";
+      tip.style.top = Math.round(top) + "px";
+    }
+    function showTip(card) {
+      if (!card || inSidebar(card)) return;
+      const d = descText(card);
+      if (!d) return;
+      clearTimeout(hideTimer);
+      tip.textContent = d;
+      tip.style.left = "-9999px";
+      tip.style.top = "0px";
+      requestAnimationFrame(() => {
+        positionTip(card);
+        requestAnimationFrame(() => tip.classList.add("svc-tooltip-visible"));
+      });
+    }
+    function hideTip() {
+      tip.classList.remove("svc-tooltip-visible");
+      hideTimer = setTimeout(() => {
+        tip.style.left = "-9999px";
+      }, 200);
+    }
+
+    let userInteracted = false;
+    ["pointerdown", "keydown", "mousemove"].forEach((evt) =>
+      window.addEventListener(
+        evt,
+        () => {
+          userInteracted = true;
+        },
+        { once: true, passive: true }
+      )
+    );
+
+    main.addEventListener("mouseover", (e) => {
+      const c = getCard(e.target);
+      if (c) showTip(c);
+    });
+    main.addEventListener("mouseout", (e) => {
+      const c = getCard(e.target),
+        to = e.relatedTarget ? getCard(e.relatedTarget) : null;
+      if (c && c !== to) hideTip();
+    });
+    main.addEventListener("focusin", (e) => {
+      if (!userInteracted) return;
+      const c = getCard(e.target);
+      if (c) showTip(c);
+    });
+    main.addEventListener("focusout", (e) => {
+      const c = getCard(e.target),
+        to = e.relatedTarget ? getCard(e.relatedTarget) : null;
+      if (c && c !== to) hideTip();
+    });
+    window.addEventListener("scroll", hideTip, { passive: true });
+    window.addEventListener("resize", hideTip);
+
+    function removeCatalogSearch() {
+      const fields = main.querySelectorAll(
+        'input[type="search"], input[type="text"], input:not([type]), [role="searchbox"], [contenteditable="true"]'
+      );
+      fields.forEach((field) => {
+        if (inSidebar(field)) return;
+        const wrap =
+          safeClosest(field, 'form[role="search"]') ||
+          safeClosest(field, '[class*="search"]') ||
+          safeClosest(field, '[class*="Search"]') ||
+          field.parentElement;
+        if (
+          wrap &&
+          wrap !== main &&
+          !wrap.querySelector('a[href*="/services/"]') &&
+          !wrap.querySelector('[data-test-id^="sidebar-category"]')
+        ) {
+          wrap.remove();
+        } else {
+          field.remove();
+        }
+      });
+    }
+
+    const DESCRIPTIONS = {
+      "all services":
+        "Browse every service available from the Service Desk, or pick a category to narrow things down.",
+      accessibility:
+        "Request accessibility reviews and support to ensure content and tools work for everyone.",
+      "account services":
+        "Manage your accounts, access, passwords, and identity credentials like PIV cards.",
+      "apps & tools":
+        "Get access to, install, or troubleshoot the software applications and tools you use day to day.",
+      aurora: "Support and requests related to the AURORA platform.",
+      collaboration:
+        "Tools and support for working together — chat, meetings, file sharing, and team spaces.",
+      "devices & equipment":
+        "Request, return, or get help with laptops, peripherals, and other hardware.",
+      "event and room support":
+        "Book and get technical support for conference rooms, events, and presentations.",
+      "get help":
+        "Report an issue or get support — outages, hardware and software problems, lost devices, security incidents, and more.",
+      grace: "Support and requests related to the GRACE platform.",
+      "help me learn":
+        "Find training, certifications, and learning resources to build your skills.",
+    };
+    const DEFAULT_DESC =
+      "Browse the services in this category and submit a request to the Service Desk.";
+    function applyCategoryDescription() {
+      const heading = Array.from(main.querySelectorAll("h1, h2, h3")).find(
+        (h) => !inSidebar(h)
+      );
+      if (!heading) return;
+      const text =
+        DESCRIPTIONS[(heading.textContent || "").trim().toLowerCase()] ||
+        DEFAULT_DESC;
+      let desc = heading.parentElement
+        ? heading.parentElement.querySelector(":scope > .svc-cat-description")
+        : null;
+      if (!desc) {
+        desc = document.createElement("p");
+        desc.className = "svc-cat-description";
+        heading.insertAdjacentElement("afterend", desc);
+      }
+      if (desc.textContent !== text) desc.textContent = text;
+    }
+
+    function enhance() {
+      [removeCatalogSearch, hideDescriptions, applyCategoryDescription].forEach(
+        (fn) => {
+          try {
+            fn();
+          } catch (e) {
+            console.warn("enhance step failed:", e);
+          }
+        }
+      );
+    }
+    enhance();
+    new MutationObserver(enhance).observe(main, {
+      childList: true,
+      subtree: true,
+    });
+  })();
+
+  // ---------------------------------------------------------------------------
+  // 2. Category-swap skeleton hiding: tag catalog grid cells that haven't
+  //    rendered their real link yet as skeletons so the CSS shimmer applies.
+  // ---------------------------------------------------------------------------
+  (function () {
+    const main = document.getElementById("service-catalog-main-content");
+    if (!main) return;
+
+    const inSidebar = (el) =>
+      !!(
+        el &&
+        el.nodeType === 1 &&
+        typeof el.closest === "function" &&
+        el.closest('[data-test-id^="sidebar-category"]')
+      );
+
+    function tagSkeletons() {
+      const cells = main.querySelectorAll(
+        '[data-testid="service-catalog-list-item-container"], [data-garden-id="grid.col"]'
+      );
+      cells.forEach((cell) => {
+        if (cell.nodeType !== 1) return;
+        if (inSidebar(cell)) return;
+        const link = cell.querySelector('a[href*="/services/"]');
+        const isSkeleton = !link || (link.textContent || "").trim().length === 0;
+        cell.classList.toggle("svc-skeleton", isSkeleton);
+      });
+    }
+
+    try {
+      tagSkeletons();
+    } catch (e) {
+      console.warn("skeleton tag failed:", e);
+    }
+    new MutationObserver(() => {
+      try {
+        tagSkeletons();
+      } catch (e) {
+        console.warn("skeleton tag failed:", e);
+      }
+    }).observe(main, { childList: true, subtree: true });
+  })();
 
 })();

--- a/src/domFixups.js
+++ b/src/domFixups.js
@@ -75,3 +75,47 @@
     document.addEventListener("DOMContentLoaded", hideEmpty);
   }
 })();
+
+// ---------------------------------------------------------------------------
+// 3. Wire the pink search-pill button (templates/search_results.hbs) to
+//    submit the native search, matching native <button type="submit"> behavior.
+//    Previously an inline <script> in that template; moved here per the
+//    "don't re-add inline scripts" rule documented in document_head.hbs.
+// ---------------------------------------------------------------------------
+(function () {
+  function wireSearchPillButton() {
+    var btn = document.getElementById("svc-search-pill-btn");
+    if (!btn || btn.dataset.svcWired === "1") return;
+    var pill = btn.closest(".svc-search-pill");
+    if (!pill) return;
+    btn.dataset.svcWired = "1";
+    btn.addEventListener("click", function () {
+      var input = pill.querySelector(
+        'input[type="search"], input[type="text"], input:not([type])'
+      );
+      if (!input) return;
+      var form = input.form || input.closest("form");
+      if (form) {
+        if (typeof form.requestSubmit === "function") form.requestSubmit();
+        else form.submit();
+      } else {
+        input.focus();
+        input.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "Enter",
+            code: "Enter",
+            keyCode: 13,
+            which: 13,
+            bubbles: true,
+          })
+        );
+      }
+    });
+  }
+
+  if (document.readyState !== "loading") {
+    wireSearchPillButton();
+  } else {
+    document.addEventListener("DOMContentLoaded", wireSearchPillButton);
+  }
+})();

--- a/src/index.js
+++ b/src/index.js
@@ -7,3 +7,6 @@ import "./search";
 import "./forms";
 import "./domFixups";
 import "./svcSearch";
+import "./svcGreeting";
+import "./svcReveal";
+import "./svcCatalogEnhancements";

--- a/src/svcCatalogEnhancements.js
+++ b/src/svcCatalogEnhancements.js
@@ -1,0 +1,304 @@
+/*
+ * Service-catalog list-page enhancements that used to be two separate inline
+ * <script> blocks in templates/service_list_page.hbs ("Catalog enhancements"
+ * and "Category-swap skeleton hiding"). Neither depends on server-rendered
+ * Curlybars data, so — same rationale as src/domFixups.js — they belong here
+ * instead of inline in the template.
+ *
+ * Both sections no-op on any page without #service-catalog-main-content, so
+ * this file is safe to include globally (bundled into script.js for every
+ * page) rather than only on the service list page.
+ *
+ * ES2015 only — this file is bundled into script.js.
+ */
+
+// ---------------------------------------------------------------------------
+// 1. Tooltips for truncated card descriptions, category description text,
+//    and removing the Zendesk service-catalog widget's own search field
+//    (the page has its own hero search instead).
+// ---------------------------------------------------------------------------
+(function () {
+  const main = document.getElementById("service-catalog-main-content");
+  if (!main) return;
+
+  const safeClosest = (el, sel) =>
+    el && el.nodeType === 1 && typeof el.closest === "function"
+      ? el.closest(sel)
+      : null;
+  const inSidebar = (el) =>
+    !!safeClosest(el, '[data-test-id^="sidebar-category"]');
+
+  const tip = document.createElement("div");
+  tip.className = "svc-tooltip";
+  tip.setAttribute("role", "tooltip");
+  tip.style.left = "-9999px";
+  tip.style.top = "-9999px";
+  document.body.appendChild(tip);
+  let hideTimer = null;
+
+  function getCard(el) {
+    if (!el || el.nodeType !== 1) return null;
+    if (inSidebar(el)) return null;
+    const card =
+      safeClosest(el, 'a[href*="/services/"]') ||
+      safeClosest(el, '[data-testid="service-catalog-list-item-container"]');
+    if (!card || inSidebar(card)) return null;
+    if (
+      !safeClosest(card, 'a[href*="/services/"]') &&
+      !card.querySelector('a[href*="/services/"]')
+    )
+      return null;
+    return card;
+  }
+  function findDescEl(card) {
+    if (!card || inSidebar(card) || typeof card.querySelectorAll !== "function")
+      return null;
+    const leaves = Array.from(card.querySelectorAll("div, p, span")).filter(
+      (el) =>
+        el &&
+        !el.querySelector(
+          "a, h1, h2, h3, h4, h5, h6, svg, img, button, div, p, span"
+        ) &&
+        (el.textContent || "").trim().length > 0
+    );
+    if (leaves.length < 2) return null;
+    const heading = card.querySelector("h1,h2,h3,h4,h5,h6");
+    const titleText = heading
+      ? heading.textContent.trim()
+      : leaves[0].textContent.trim();
+    return (
+      leaves.find((l) => {
+        const t = l.textContent.trim();
+        return t && t !== titleText;
+      }) || null
+    );
+  }
+  function descText(card) {
+    const el = findDescEl(card);
+    if (!el) return "";
+    const t = el.textContent.trim();
+    if (/^\d+$/.test(t)) return "";
+    return t;
+  }
+
+  function hideDescriptions() {
+    main
+      .querySelectorAll(
+        'a[href*="/services/"], [class*="card"], [class*="Card"]'
+      )
+      .forEach((card) => {
+        if (inSidebar(card)) return;
+        const el = findDescEl(card);
+        if (el && !el.classList.contains("svc-desc-hidden"))
+          el.classList.add("svc-desc-hidden");
+      });
+  }
+  function positionTip(card) {
+    const rect = card.getBoundingClientRect();
+    tip.style.maxWidth = Math.max(180, Math.min(240, rect.width + 20)) + "px";
+    const t = tip.getBoundingClientRect(),
+      gap = 8;
+    let left = Math.min(
+      Math.max(rect.left, 12),
+      window.innerWidth - t.width - 12
+    );
+    tip.style.setProperty(
+      "--svc-arrow-left",
+      Math.max(
+        10,
+        Math.min(t.width - 18, rect.left + rect.width / 2 - left - 4)
+      ) + "px"
+    );
+    let top;
+    if (window.innerHeight - rect.bottom > t.height + gap + 12) {
+      top = rect.bottom + gap;
+      tip.classList.add("svc-tooltip-below");
+      tip.classList.remove("svc-tooltip-above");
+    } else {
+      top = rect.top - t.height - gap;
+      tip.classList.add("svc-tooltip-above");
+      tip.classList.remove("svc-tooltip-below");
+    }
+    tip.style.left = Math.round(left) + "px";
+    tip.style.top = Math.round(top) + "px";
+  }
+  function showTip(card) {
+    if (!card || inSidebar(card)) return;
+    const d = descText(card);
+    if (!d) return;
+    clearTimeout(hideTimer);
+    tip.textContent = d;
+    tip.style.left = "-9999px";
+    tip.style.top = "0px";
+    requestAnimationFrame(() => {
+      positionTip(card);
+      requestAnimationFrame(() => tip.classList.add("svc-tooltip-visible"));
+    });
+  }
+  function hideTip() {
+    tip.classList.remove("svc-tooltip-visible");
+    hideTimer = setTimeout(() => {
+      tip.style.left = "-9999px";
+    }, 200);
+  }
+
+  let userInteracted = false;
+  ["pointerdown", "keydown", "mousemove"].forEach((evt) =>
+    window.addEventListener(
+      evt,
+      () => {
+        userInteracted = true;
+      },
+      { once: true, passive: true }
+    )
+  );
+
+  main.addEventListener("mouseover", (e) => {
+    const c = getCard(e.target);
+    if (c) showTip(c);
+  });
+  main.addEventListener("mouseout", (e) => {
+    const c = getCard(e.target),
+      to = e.relatedTarget ? getCard(e.relatedTarget) : null;
+    if (c && c !== to) hideTip();
+  });
+  main.addEventListener("focusin", (e) => {
+    if (!userInteracted) return;
+    const c = getCard(e.target);
+    if (c) showTip(c);
+  });
+  main.addEventListener("focusout", (e) => {
+    const c = getCard(e.target),
+      to = e.relatedTarget ? getCard(e.relatedTarget) : null;
+    if (c && c !== to) hideTip();
+  });
+  window.addEventListener("scroll", hideTip, { passive: true });
+  window.addEventListener("resize", hideTip);
+
+  function removeCatalogSearch() {
+    const fields = main.querySelectorAll(
+      'input[type="search"], input[type="text"], input:not([type]), [role="searchbox"], [contenteditable="true"]'
+    );
+    fields.forEach((field) => {
+      if (inSidebar(field)) return;
+      const wrap =
+        safeClosest(field, 'form[role="search"]') ||
+        safeClosest(field, '[class*="search"]') ||
+        safeClosest(field, '[class*="Search"]') ||
+        field.parentElement;
+      if (
+        wrap &&
+        wrap !== main &&
+        !wrap.querySelector('a[href*="/services/"]') &&
+        !wrap.querySelector('[data-test-id^="sidebar-category"]')
+      ) {
+        wrap.remove();
+      } else {
+        field.remove();
+      }
+    });
+  }
+
+  const DESCRIPTIONS = {
+    "all services":
+      "Browse every service available from the Service Desk, or pick a category to narrow things down.",
+    accessibility:
+      "Request accessibility reviews and support to ensure content and tools work for everyone.",
+    "account services":
+      "Manage your accounts, access, passwords, and identity credentials like PIV cards.",
+    "apps & tools":
+      "Get access to, install, or troubleshoot the software applications and tools you use day to day.",
+    aurora: "Support and requests related to the AURORA platform.",
+    collaboration:
+      "Tools and support for working together — chat, meetings, file sharing, and team spaces.",
+    "devices & equipment":
+      "Request, return, or get help with laptops, peripherals, and other hardware.",
+    "event and room support":
+      "Book and get technical support for conference rooms, events, and presentations.",
+    "get help":
+      "Report an issue or get support — outages, hardware and software problems, lost devices, security incidents, and more.",
+    grace: "Support and requests related to the GRACE platform.",
+    "help me learn":
+      "Find training, certifications, and learning resources to build your skills.",
+  };
+  const DEFAULT_DESC =
+    "Browse the services in this category and submit a request to the Service Desk.";
+  function applyCategoryDescription() {
+    const heading = Array.from(main.querySelectorAll("h1, h2, h3")).find(
+      (h) => !inSidebar(h)
+    );
+    if (!heading) return;
+    const text =
+      DESCRIPTIONS[(heading.textContent || "").trim().toLowerCase()] ||
+      DEFAULT_DESC;
+    let desc = heading.parentElement
+      ? heading.parentElement.querySelector(":scope > .svc-cat-description")
+      : null;
+    if (!desc) {
+      desc = document.createElement("p");
+      desc.className = "svc-cat-description";
+      heading.insertAdjacentElement("afterend", desc);
+    }
+    if (desc.textContent !== text) desc.textContent = text;
+  }
+
+  function enhance() {
+    [removeCatalogSearch, hideDescriptions, applyCategoryDescription].forEach(
+      (fn) => {
+        try {
+          fn();
+        } catch (e) {
+          console.warn("enhance step failed:", e);
+        }
+      }
+    );
+  }
+  enhance();
+  new MutationObserver(enhance).observe(main, {
+    childList: true,
+    subtree: true,
+  });
+})();
+
+// ---------------------------------------------------------------------------
+// 2. Category-swap skeleton hiding: tag catalog grid cells that haven't
+//    rendered their real link yet as skeletons so the CSS shimmer applies.
+// ---------------------------------------------------------------------------
+(function () {
+  const main = document.getElementById("service-catalog-main-content");
+  if (!main) return;
+
+  const inSidebar = (el) =>
+    !!(
+      el &&
+      el.nodeType === 1 &&
+      typeof el.closest === "function" &&
+      el.closest('[data-test-id^="sidebar-category"]')
+    );
+
+  function tagSkeletons() {
+    const cells = main.querySelectorAll(
+      '[data-testid="service-catalog-list-item-container"], [data-garden-id="grid.col"]'
+    );
+    cells.forEach((cell) => {
+      if (cell.nodeType !== 1) return;
+      if (inSidebar(cell)) return;
+      const link = cell.querySelector('a[href*="/services/"]');
+      const isSkeleton = !link || (link.textContent || "").trim().length === 0;
+      cell.classList.toggle("svc-skeleton", isSkeleton);
+    });
+  }
+
+  try {
+    tagSkeletons();
+  } catch (e) {
+    console.warn("skeleton tag failed:", e);
+  }
+  new MutationObserver(() => {
+    try {
+      tagSkeletons();
+    } catch (e) {
+      console.warn("skeleton tag failed:", e);
+    }
+  }).observe(main, { childList: true, subtree: true });
+})();

--- a/src/svcGreeting.js
+++ b/src/svcGreeting.js
@@ -1,0 +1,77 @@
+/*
+ * Shared "who is this user" name-resolution helper for the service-catalog
+ * personalized greetings.
+ *
+ * Previously this fetch + alias/first-name parsing logic was copy-pasted
+ * almost line-for-line inline in both templates/service_page.hbs and
+ * templates/service_list_page.hbs (one ES5, one ES6, otherwise identical).
+ * Centralized here — same rationale as src/svcSearch.js, which already
+ * consolidated the duplicated search widget logic out of these same two
+ * templates.
+ *
+ * Each page still composes its own greeting text/reveal-timing around the
+ * resolved name (that part genuinely differs per page), so this module only
+ * owns the "fetch the signed-in user and pick a real display name" part.
+ *
+ * ES2015 only — this file is bundled into script.js.
+ */
+
+function looksLikeAlias(v) {
+  if (!v) return true;
+  var s = String(v).trim();
+  if (!s) return true;
+  if (s.indexOf("@") !== -1) return true;
+  if (/^[a-z0-9._-]+$/.test(s) && s.indexOf(" ") === -1) return true;
+  return false;
+}
+
+function firstNameOf(name) {
+  var s = String(name || "").trim();
+  if (!s) return "";
+  if (s.indexOf(",") !== -1) {
+    var parts = s
+      .split(",")
+      .map(function (p) {
+        return p.trim();
+      })
+      .filter(Boolean);
+    if (parts.length >= 2) return parts[1].split(/\s+/)[0];
+  }
+  return s.split(/\s+/)[0];
+}
+
+// Fetches the signed-in user and calls back with their resolved first name
+// (or "" if unavailable/anonymous/alias-only). Never rejects — network or
+// parsing failures resolve to "" so callers don't need their own try/catch.
+window.svcFetchFirstName = function (callback) {
+  fetch("/api/v2/users/me.json", {
+    headers: { Accept: "application/json" },
+    credentials: "same-origin",
+  })
+    .then(function (r) {
+      return r.ok ? r.json() : null;
+    })
+    .then(function (d) {
+      var u = d && d.user;
+      if (!u) {
+        callback("");
+        return;
+      }
+      var candidates = [
+        u.name,
+        u.details && u.details.name,
+        u.user_fields &&
+          (u.user_fields.full_name ||
+            u.user_fields.preferred_name ||
+            u.user_fields.first_name),
+      ];
+      var realName =
+        candidates.find(function (c) {
+          return !looksLikeAlias(c);
+        }) || u.name;
+      callback(firstNameOf(realName));
+    })
+    .catch(function () {
+      callback("");
+    });
+};

--- a/src/svcReveal.js
+++ b/src/svcReveal.js
@@ -1,0 +1,70 @@
+/*
+ * Shared "reveal once the async content is ready" controller for the
+ * service-catalog skeleton placeholders.
+ *
+ * Previously this MutationObserver + settle-timer + hard-timeout + bfcache
+ * pattern was duplicated (with only the completion check and target/skeleton
+ * ids differing) between templates/service_page.hbs (form skeleton) and
+ * templates/service_list_page.hbs (catalog skeleton). Centralized here so
+ * both pages configure the same controller instead of re-implementing it.
+ *
+ * ES2015 only — this file is bundled into script.js.
+ */
+
+// options:
+//   targetId       (required) id of the element to observe for completion
+//   skeletonId     (optional) id of the skeleton placeholder to hide/remove
+//   readyClasses   (optional) array of classes added to <html> once revealed
+//   isComplete(el) (required) returns true once `el` has its real content
+//   settleMs       (optional, default 400) debounce after isComplete() first
+//                  passes, so we don't reveal mid-render
+//   hardCapMs      (optional, default 6000) reveal unconditionally by this
+//                  point even if isComplete() never returns true
+//   onReveal()     (optional) extra callback once revealed
+window.initSvcRevealOnComplete = function (options) {
+  var root = document.documentElement;
+  var target = document.getElementById(options.targetId);
+  if (!target) return;
+  var skel = options.skeletonId
+    ? document.getElementById(options.skeletonId)
+    : null;
+
+  var done = false;
+  function reveal() {
+    if (done) return;
+    done = true;
+    (options.readyClasses || []).forEach(function (c) {
+      root.classList.add(c);
+    });
+    if (skel) {
+      skel.classList.add(options.skeletonHideClass || "svc-skel-hide");
+      setTimeout(function () {
+        if (skel && skel.parentNode) skel.parentNode.removeChild(skel);
+      }, 320);
+    }
+    if (options.onReveal) options.onReveal();
+  }
+
+  var settleTimer = null;
+  function armSettle() {
+    if (settleTimer) clearTimeout(settleTimer);
+    settleTimer = setTimeout(reveal, options.settleMs || 400);
+  }
+  function check() {
+    if (!done && options.isComplete(target)) armSettle();
+  }
+
+  check();
+  var mo = new MutationObserver(check);
+  mo.observe(target, { childList: true, subtree: true });
+  (function stop() {
+    if (done) mo.disconnect();
+    else setTimeout(stop, 300);
+  })();
+
+  setTimeout(reveal, options.hardCapMs || 6000);
+
+  window.addEventListener("pageshow", function (e) {
+    if (e.persisted) reveal();
+  });
+};

--- a/style.css
+++ b/style.css
@@ -181,6 +181,147 @@ template {
   display: none;
 }
 
+/* ============================================================
+   ARPA-H custom — self-hosted type
+   Public Sans (USWDS / ARPA-H standard body type) and Poppins
+   (NEXUS display type) are self-hosted from /assets rather than
+   pulled from a third-party font CDN (privacy/CSP concern on a
+   federal site). Referenced via the `$assets-<filename>-<ext>`
+   convention that zass.mjs/Zendesk's asset pipeline resolves to
+   the real CDN URL at serve time — the same mechanism used for
+   settings-driven images like $homepage_background_image.
+   font-display: swap avoids invisible text while the woff2 loads.
+   Weights 400/500/600/700, latin + latin-ext (latin-ext covers
+   accented names).
+   ============================================================ */
+@font-face {
+  font-family: "Public Sans";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url($assets-public-sans-400-latin_ext-woff2) format("woff2");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: "Public Sans";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url($assets-public-sans-400-latin-woff2) format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: "Public Sans";
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url($assets-public-sans-500-latin_ext-woff2) format("woff2");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: "Public Sans";
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url($assets-public-sans-500-latin-woff2) format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: "Public Sans";
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url($assets-public-sans-600-latin_ext-woff2) format("woff2");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: "Public Sans";
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url($assets-public-sans-600-latin-woff2) format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: "Public Sans";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url($assets-public-sans-700-latin_ext-woff2) format("woff2");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: "Public Sans";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url($assets-public-sans-700-latin-woff2) format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: "Poppins";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url($assets-poppins-400-latin_ext-woff2) format("woff2");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: "Poppins";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url($assets-poppins-400-latin-woff2) format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: "Poppins";
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url($assets-poppins-500-latin_ext-woff2) format("woff2");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: "Poppins";
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url($assets-poppins-500-latin-woff2) format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: "Poppins";
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url($assets-poppins-600-latin_ext-woff2) format("woff2");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: "Poppins";
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url($assets-poppins-600-latin-woff2) format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: "Poppins";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url($assets-poppins-700-latin_ext-woff2) format("woff2");
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: "Poppins";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url($assets-poppins-700-latin-woff2) format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
 /***** Base *****/
 * {
   box-sizing: border-box;
@@ -558,7 +699,7 @@ ul {
   border-radius: 4px;
   border: 1px solid #848F99;
   height: 80px;
-  line-height: 40px;
+  line-height: 80px;
   outline: none;
   vertical-align: middle;
 }
@@ -926,7 +1067,7 @@ ul {
 
 /***** Header "Submit a request" nav button *****/
 .nav-wrapper-desktop .submit-a-request {
-  border: 1px solid #0957BE;
+  border: 1px solid $brand_color;
   border-radius: 8px;
   box-sizing: border-box;
   color: $brand_color;
@@ -1336,7 +1477,7 @@ nav[aria-label=Breadcrumb] a[aria-disabled=true] {
   }
 }
 .blocks-item {
-  border: 1px solid #E5EAF0;
+  border: 1px solid var(--svc-line);
   border-radius: 12px;
   box-sizing: border-box;
   color: $brand_color;
@@ -5217,6 +5358,24 @@ html body .header .search-wrapper {
   display: none !important;
 }
 
+/* Shared skeleton-loading shimmer sweep. Used by the category/list skeleton
+   placeholders in _svc-home.scss and the item-page skeleton in
+   _svc-service-item.scss — defined once here so both @extend the same
+   gradient/animation instead of duplicating it. */
+@keyframes svcSkelShimmer {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+.svc-skel-avatar, .svc-skel-bar, .svc-skel-input, .svc-skel-box, .svc-cat-skel-row, .svc-cat-skel-heading, .svc-cat-skel-subtext, .svc-cat-skel-card {
+  background: linear-gradient(100deg, var(--svc-line) 30%, #f6f8fc 50%, var(--svc-line) 70%);
+  background-size: 200% 100%;
+  animation: svcSkelShimmer 1.3s ease-in-out infinite;
+}
+
 /* ============================================================
    ARPA-H custom — home page (service_list_page): hero, combined
    live search, service-catalog card, skeleton loader, tooltips.
@@ -5925,20 +6084,6 @@ a.svc-help-btn:hover,
 }
 
 /* Shimmer sweep */
-.svc-cat-skel-row, .svc-cat-skel-heading, .svc-cat-skel-subtext, .svc-cat-skel-card {
-  background: linear-gradient(100deg, #e5eaf0 30%, #f6f8fc 50%, #e5eaf0 70%);
-  background-size: 200% 100%;
-  animation: svcSkelShimmer 1.3s ease-in-out infinite;
-}
-
-@keyframes svcSkelShimmer {
-  from {
-    background-position: 200% 0;
-  }
-  to {
-    background-position: -200% 0;
-  }
-}
 /* Category-swap: hide Zendesk's gray skeleton "loading" boxes */
 .service-catalog-main-content .svc-skeleton {
   visibility: hidden !important;
@@ -6315,13 +6460,13 @@ body {
 
 .svc-step-active {
   background: #ffffff;
-  color: #09349d;
+  color: var(--svc-navy);
   border-color: #b9c9ef;
   box-shadow: 0 2px 6px rgba(0, 51, 153, 0.12);
 }
 
 .svc-step-active .svc-step-number {
-  background: #09349d;
+  background: var(--svc-navy);
   color: #ffffff;
 }
 
@@ -6427,7 +6572,7 @@ body {
   display: block;
   font-size: 13px;
   font-weight: 600;
-  color: #09349d;
+  color: var(--svc-navy);
   margin-bottom: 4px;
 }
 
@@ -6596,7 +6741,7 @@ body {
 }
 
 .svc-custom-submit-btn:hover {
-  background: #001b5e;
+  background: var(--svc-navy-deep);
 }
 
 .svc-custom-submit-btn:focus {
@@ -6693,12 +6838,12 @@ body {
 .svc-help-banner-title {
   font-size: 15px;
   font-weight: 600;
-  color: #252729;
+  color: var(--svc-ink);
 }
 
 .svc-help-banner-sub {
   font-size: 13px;
-  color: #6f747a;
+  color: var(--svc-gray);
 }
 
 .svc-help-btn {
@@ -6711,15 +6856,15 @@ body {
   font-size: 13.5px;
   font-weight: 600;
   text-align: center;
-  color: #09349d !important;
+  color: var(--svc-navy) !important;
   text-decoration: none !important;
   background: #ffffff;
-  border: 1.5px solid #09349d;
+  border: 1.5px solid var(--svc-navy);
   transition: background-color 0.16s ease, color 0.16s ease;
 }
 
 .svc-help-btn:hover {
-  background: #09349d;
+  background: var(--svc-navy);
   color: #ffffff !important;
 }
 
@@ -6737,7 +6882,7 @@ body {
   max-width: 52px;
   padding: 0;
   border-radius: 1000px;
-  background: linear-gradient(145deg, #c93678, #fd4497);
+  background: linear-gradient(145deg, var(--svc-pink-deep), var(--svc-pink));
   color: #ffffff !important;
   text-decoration: none !important;
   overflow: hidden;
@@ -6899,7 +7044,7 @@ body {
 
 .svc-skel-divider {
   height: 1px;
-  background: #e5eaf0;
+  background: var(--svc-line);
   margin: 18px 0;
 }
 
@@ -6925,20 +7070,6 @@ body {
   border-radius: 8px;
 }
 
-.svc-skel-avatar, .svc-skel-bar, .svc-skel-input, .svc-skel-box {
-  background: linear-gradient(100deg, #e5eaf0 30%, #f6f8fc 50%, #e5eaf0 70%);
-  background-size: 200% 100%;
-  animation: svcSkelShimmer 1.3s ease-in-out infinite;
-}
-
-@keyframes svcSkelShimmer {
-  from {
-    background-position: 200% 0;
-  }
-  to {
-    background-position: -200% 0;
-  }
-}
 body > pre, body > code, body > .template-name, body > .editor-label {
   display: none !important;
 }
@@ -7017,7 +7148,7 @@ body > pre, body > code, body > .template-name, body > .editor-label {
 }
 
 .svc-mini-search-btn:hover {
-  background: #001b5e;
+  background: var(--svc-navy-deep);
 }
 
 .svc-mini-results {
@@ -7028,7 +7159,7 @@ body > pre, body > code, body > .template-name, body > .editor-label {
   overflow-y: auto;
   background: #ffffff;
   border-radius: 16px;
-  border: 1px solid #e5eaf0;
+  border: 1px solid var(--svc-line);
   box-shadow: 0 16px 40px rgba(15, 33, 80, 0.16);
   text-align: left;
 }
@@ -7038,11 +7169,11 @@ body > pre, body > code, body > .template-name, body > .editor-label {
   align-items: center;
   gap: 8px;
   padding: 12px 16px 6px;
-  border-bottom: 0.5px solid #e5eaf0;
+  border-bottom: 0.5px solid var(--svc-line);
 }
 
 .svc-mr-group-header.svc-mr-docs {
-  border-top: 0.5px solid #e5eaf0;
+  border-top: 0.5px solid var(--svc-line);
   background: #fcfcfd;
 }
 
@@ -7054,11 +7185,11 @@ body > pre, body > code, body > .template-name, body > .editor-label {
 }
 
 .svc-mr-services .svc-mr-group-title {
-  color: #09349d;
+  color: var(--svc-navy);
 }
 
 .svc-mr-docs .svc-mr-group-title {
-  color: #09349d;
+  color: var(--svc-navy);
 }
 
 .svc-mr-group-count {
@@ -7081,7 +7212,7 @@ body > pre, body > code, body > .template-name, body > .editor-label {
 }
 
 .svc-mr-item.svc-mr-service {
-  border-left: 3px solid #09349d;
+  border-left: 3px solid var(--svc-navy);
 }
 
 .svc-mr-item.svc-mr-doc {
@@ -7099,8 +7230,8 @@ body > pre, body > code, body > .template-name, body > .editor-label {
 }
 
 .svc-mr-service .svc-mr-icon {
-  background: #e6f5fc;
-  color: #09349d;
+  background: var(--svc-tint);
+  color: var(--svc-navy);
 }
 
 .svc-mr-doc .svc-mr-icon {
@@ -7127,13 +7258,13 @@ body > pre, body > code, body > .template-name, body > .editor-label {
 
 .svc-mr-title {
   font-size: 13.5px;
-  color: #252729;
+  color: var(--svc-ink);
   text-decoration: none;
 }
 
 .svc-mr-sub {
   font-size: 12px;
-  color: #959ba3;
+  color: var(--svc-gray-soft);
 }
 
 .svc-mr-badge {
@@ -7145,29 +7276,29 @@ body > pre, body > code, body > .template-name, body > .editor-label {
 }
 
 .svc-mr-service .svc-mr-badge {
-  color: #09349d;
-  background: #e6f5fc;
+  color: var(--svc-navy);
+  background: var(--svc-tint);
 }
 
 .svc-mr-doc .svc-mr-badge {
   color: #6b7280;
-  background: #e5eaf0;
+  background: var(--svc-line);
 }
 
 .svc-mr-empty, .svc-mr-loading {
   padding: 16px;
   font-size: 13px;
-  color: #959ba3;
+  color: var(--svc-gray-soft);
   text-align: center;
 }
 
 .svc-mr-footer {
   display: block;
   padding: 11px 16px;
-  border-top: 0.5px solid #e5eaf0;
+  border-top: 0.5px solid var(--svc-line);
   font-size: 12.5px;
   font-weight: 500;
-  color: #09349d;
+  color: var(--svc-navy);
   text-align: center;
   text-decoration: none;
 }
@@ -7517,21 +7648,6 @@ body > pre, body > code, body > .template-name, body > .editor-label {
   order: 2;
 }
 
-.header .logo {
-  display: flex;
-  align-items: center;
-  flex: 0 0 auto;
-  order: 1;
-}
-
-.header .nav-wrapper-desktop {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  flex: 0 0 auto;
-  order: 2;
-}
-
 html.svc-home .header .search-wrapper {
   display: none !important;
 }
@@ -7672,7 +7788,7 @@ html.svc-home .header .search-wrapper {
     right: 12px;
     left: 12px;
     background: #ffffff;
-    border: 1px solid #e5eaf0;
+    border: 1px solid var(--svc-line);
     border-radius: 16px;
     box-shadow: 0 16px 40px rgba(15, 33, 80, 0.16);
     padding: 8px;
@@ -7692,16 +7808,16 @@ html.svc-home .header .search-wrapper {
     padding: 10px 12px;
     border-radius: 8px;
     font-size: 14px;
-    color: #252729;
+    color: var(--svc-ink);
     text-decoration: none;
   }
   .header .menu-list-mobile-items .item a:hover {
     background: #f5f8ff;
-    color: #09349d;
+    color: var(--svc-navy);
   }
   .header .menu-list-mobile-items .nav-divider {
     height: 1px;
-    background: #e5eaf0;
+    background: var(--svc-line);
     margin: 6px 4px;
   }
 }

--- a/styles/_blocks.scss
+++ b/styles/_blocks.scss
@@ -27,7 +27,7 @@
       &:last-child  { margin-right: 0; }
     }
 
-    border: 1px solid #E5EAF0;
+    border: 1px solid var(--svc-line);
     border-radius: 12px;
     box-sizing: border-box;
     color: $brand_color;

--- a/styles/_fonts.scss
+++ b/styles/_fonts.scss
@@ -1,0 +1,88 @@
+/* ============================================================
+   ARPA-H custom — self-hosted type
+   Public Sans (USWDS / ARPA-H standard body type) and Poppins
+   (NEXUS display type) are self-hosted from /assets rather than
+   pulled from a third-party font CDN (privacy/CSP concern on a
+   federal site). Referenced via the `$assets-<filename>-<ext>`
+   convention that zass.mjs/Zendesk's asset pipeline resolves to
+   the real CDN URL at serve time — the same mechanism used for
+   settings-driven images like $homepage_background_image.
+   font-display: swap avoids invisible text while the woff2 loads.
+   Weights 400/500/600/700, latin + latin-ext (latin-ext covers
+   accented names).
+   ============================================================ */
+
+@mixin arpah-font-face($family, $weight, $latin-font, $latin-ext-font) {
+  @font-face {
+    font-family: $family;
+    font-style: normal;
+    font-weight: $weight;
+    font-display: swap;
+    src: url($latin-ext-font) format("woff2");
+    unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7,
+      U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F,
+      U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+      U+A720-A7FF;
+  }
+
+  @font-face {
+    font-family: $family;
+    font-style: normal;
+    font-weight: $weight;
+    font-display: swap;
+    src: url($latin-font) format("woff2");
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
+      U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
+      U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+}
+
+@include arpah-font-face(
+  "Public Sans",
+  400,
+  $assets-public-sans-400-latin-woff2,
+  $assets-public-sans-400-latin_ext-woff2
+);
+@include arpah-font-face(
+  "Public Sans",
+  500,
+  $assets-public-sans-500-latin-woff2,
+  $assets-public-sans-500-latin_ext-woff2
+);
+@include arpah-font-face(
+  "Public Sans",
+  600,
+  $assets-public-sans-600-latin-woff2,
+  $assets-public-sans-600-latin_ext-woff2
+);
+@include arpah-font-face(
+  "Public Sans",
+  700,
+  $assets-public-sans-700-latin-woff2,
+  $assets-public-sans-700-latin_ext-woff2
+);
+
+@include arpah-font-face(
+  "Poppins",
+  400,
+  $assets-poppins-400-latin-woff2,
+  $assets-poppins-400-latin_ext-woff2
+);
+@include arpah-font-face(
+  "Poppins",
+  500,
+  $assets-poppins-500-latin-woff2,
+  $assets-poppins-500-latin_ext-woff2
+);
+@include arpah-font-face(
+  "Poppins",
+  600,
+  $assets-poppins-600-latin-woff2,
+  $assets-poppins-600-latin_ext-woff2
+);
+@include arpah-font-face(
+  "Poppins",
+  700,
+  $assets-poppins-700-latin-woff2,
+  $assets-poppins-700-latin_ext-woff2
+);

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -39,7 +39,10 @@
   border-radius: 4px;
   border: 1px solid $high-contrast-border-color;
   height: 80px;
-  line-height: 40px;
+  // line-height matches height so single-line text stays vertically
+  // centered in the taller (accessibility touch-target) box; was
+  // previously left at the pre-bump 40px, which top-aligned the text.
+  line-height: 80px;
   outline: none;
   vertical-align: middle;
 

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -335,7 +335,10 @@ $header-height: 71px;
 /***** Header "Submit a request" nav button *****/
 
 .nav-wrapper-desktop .submit-a-request {
-  border: 1px solid #0957BE;
+  // Was hardcoded to #0957BE; matches $brand_color like the rest of this
+  // rule so the border stays in sync if brand_color is changed in Theming
+  // Center settings.
+  border: 1px solid $brand_color;
   border-radius: 8px;
   box-sizing: border-box;
   color: $brand_color;
@@ -355,6 +358,9 @@ $header-height: 71px;
   }
 }
 
+// Unscoped (not just .nav-wrapper-desktop) because this same 'submit_a_request'
+// link is also rendered in .nav-wrapper-mobile (templates/header.hbs), which
+// has no focus/active rule of its own.
 .submit-a-request:focus,
 .submit-a-request:active {
   background-color: $brand_color;

--- a/styles/_svc-header.scss
+++ b/styles/_svc-header.scss
@@ -14,19 +14,6 @@
   flex: 0 0 auto;
   order: 2;
 }
-.header .logo {
-  display: flex;
-  align-items: center;
-  flex: 0 0 auto;
-  order: 1;
-}
-.header .nav-wrapper-desktop {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  flex: 0 0 auto;
-  order: 2;
-}
 html.svc-home .header .search-wrapper {
   display: none !important;
 }
@@ -139,7 +126,7 @@ html.svc-home .header .search-wrapper {
     right: 12px;
     left: 12px;
     background: #ffffff;
-    border: 1px solid #e5eaf0;
+    border: 1px solid var(--svc-line);
     border-radius: 16px;
     box-shadow: 0 16px 40px rgba(15, 33, 80, 0.16);
     padding: 8px;
@@ -153,11 +140,11 @@ html.svc-home .header .search-wrapper {
     padding: 10px 12px;
     border-radius: 8px;
     font-size: 14px;
-    color: #252729;
+    color: var(--svc-ink);
     text-decoration: none;
   }
-  .header .menu-list-mobile-items .item a:hover { background: #f5f8ff; color: #09349d; }
-  .header .menu-list-mobile-items .nav-divider { height: 1px; background: #e5eaf0; margin: 6px 4px; }
+  .header .menu-list-mobile-items .item a:hover { background: #f5f8ff; color: var(--svc-navy); }
+  .header .menu-list-mobile-items .nav-divider { height: 1px; background: var(--svc-line); margin: 6px 4px; }
 }
 
 .header .user-info .dropdown-toggle .svc-username {

--- a/styles/_svc-home.scss
+++ b/styles/_svc-home.scss
@@ -441,13 +441,7 @@ a.svc-help-btn:hover,
 
 /* Shimmer sweep */
 .svc-cat-skel-row, .svc-cat-skel-heading, .svc-cat-skel-subtext, .svc-cat-skel-card {
-  background: linear-gradient(100deg, #e5eaf0 30%, #f6f8fc 50%, #e5eaf0 70%);
-  background-size: 200% 100%;
-  animation: svcSkelShimmer 1.3s ease-in-out infinite;
-}
-@keyframes svcSkelShimmer {
-  from { background-position: 200% 0; }
-  to   { background-position: -200% 0; }
+  @extend %svc-skel-shimmer;
 }
 
 /* Category-swap: hide Zendesk's gray skeleton "loading" boxes */

--- a/styles/_svc-service-item.scss
+++ b/styles/_svc-service-item.scss
@@ -70,8 +70,8 @@ body { background: #ffffff; }
   display: inline-flex; align-items: center; justify-content: center;
   font-size: 10px; font-weight: 600;
 }
-.svc-step-active { background: #ffffff; color: #09349d; border-color: #b9c9ef; box-shadow: 0 2px 6px rgba(0, 51, 153, 0.12); }
-.svc-step-active .svc-step-number { background: #09349d; color: #ffffff; }
+.svc-step-active { background: #ffffff; color: var(--svc-navy); border-color: #b9c9ef; box-shadow: 0 2px 6px rgba(0, 51, 153, 0.12); }
+.svc-step-active .svc-step-number { background: var(--svc-navy); color: #ffffff; }
 .svc-step-label { font-weight: 500; white-space: nowrap; }
 
 /* ---- CONTENT LAYOUT (form + sidebar) ---- */
@@ -119,7 +119,7 @@ body { background: #ffffff; }
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 .svc-article-item:hover { border-color: #bfd0f3; box-shadow: 0 8px 18px rgba(15, 33, 80, 0.08); transform: translateY(-1px); }
-.svc-article-item-title { display: block; font-size: 13px; font-weight: 600; color: #09349d; margin-bottom: 4px; }
+.svc-article-item-title { display: block; font-size: 13px; font-weight: 600; color: var(--svc-navy); margin-bottom: 4px; }
 .svc-article-item-meta { display: block; font-size: 12px; color: #6b7280; line-height: 1.45; }
 
 /* ---- CATALOG FORM WIDTH OVERRIDES ---- */
@@ -224,7 +224,7 @@ body { background: #ffffff; }
   font-weight: 700; letter-spacing: 0.01em; border: none; cursor: pointer; box-shadow: none;
   transition: background-color 0.18s ease, filter 0.18s ease;
 }
-.svc-custom-submit-btn:hover { background: #001b5e; }
+.svc-custom-submit-btn:hover { background: var(--svc-navy-deep); }
 .svc-custom-submit-btn:focus { outline: none; }
 .svc-custom-submit-btn:focus-visible { outline: 2px solid #6ea8ff; outline-offset: 2px; }
 .svc-custom-submit-btn:active { background: #001f56; filter: brightness(0.97); }
@@ -263,8 +263,8 @@ body { background: #ffffff; }
   background: #f7f9ff;
 }
 .svc-help-banner-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.svc-help-banner-title { font-size: 15px; font-weight: 600; color: #252729; }
-.svc-help-banner-sub { font-size: 13px; color: #6f747a; }
+.svc-help-banner-title { font-size: 15px; font-weight: 600; color: var(--svc-ink); }
+.svc-help-banner-sub { font-size: 13px; color: var(--svc-gray); }
 .svc-help-btn {
   display: inline-flex; align-items: center; justify-content: center;
   flex-shrink: 0;
@@ -272,20 +272,20 @@ body { background: #ffffff; }
   border-radius: 1000px;
   font-size: 13.5px; font-weight: 600;
   text-align: center;
-  color: #09349d !important;
+  color: var(--svc-navy) !important;
   text-decoration: none !important;
   background: #ffffff;
-  border: 1.5px solid #09349d;
+  border: 1.5px solid var(--svc-navy);
   transition: background-color 0.16s ease, color 0.16s ease;
 }
-.svc-help-btn:hover { background: #09349d; color: #ffffff !important; }
+.svc-help-btn:hover { background: var(--svc-navy); color: #ffffff !important; }
 
 /* ---- FLOATING TRAINING BUTTON ---- */
 .svc-training-fab {
   position: fixed; right: 24px; bottom: 24px; z-index: 9000;
   display: inline-flex; align-items: center; gap: 0;
   height: 52px; width: 52px; max-width: 52px; padding: 0; border-radius: 1000px;
-  background: linear-gradient(145deg, #c93678, #fd4497);
+  background: linear-gradient(145deg, var(--svc-pink-deep), var(--svc-pink));
   color: #ffffff !important; text-decoration: none !important;
   overflow: hidden; white-space: nowrap; box-shadow: 0 8px 20px rgba(253, 68, 151, 0.32);
   transition: max-width 0.34s cubic-bezier(0.22, 1, 0.36, 1), width 0.34s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.24s ease, transform 0.24s ease;
@@ -336,20 +336,14 @@ body { background: #ffffff; }
 .svc-skel-bar { height: 14px; border-radius: 8px; }
 .svc-skel-title { width: 60%; height: 22px; }
 .svc-skel-sub { width: 85%; }
-.svc-skel-divider { height: 1px; background: #e5eaf0; margin: 18px 0; }
+.svc-skel-divider { height: 1px; background: var(--svc-line); margin: 18px 0; }
 .svc-skel-label { width: 30%; height: 12px; margin-bottom: 10px; }
 .svc-skel-label-2 { margin-top: 22px; }
 .svc-skel-input { width: 100%; height: 40px; border-radius: 8px; }
 .svc-skel-box { width: 100%; height: 120px; border-radius: 8px; }
 
 .svc-skel-avatar, .svc-skel-bar, .svc-skel-input, .svc-skel-box {
-  background: linear-gradient(100deg, #e5eaf0 30%, #f6f8fc 50%, #e5eaf0 70%);
-  background-size: 200% 100%;
-  animation: svcSkelShimmer 1.3s ease-in-out infinite;
-}
-@keyframes svcSkelShimmer {
-  from { background-position: 200% 0; }
-  to   { background-position: -200% 0; }
+  @extend %svc-skel-shimmer;
 }
 
 body > pre, body > code, body > .template-name, body > .editor-label { display: none !important; }
@@ -394,7 +388,7 @@ body > pre, body > code, body > .template-name, body > .editor-label { display: 
   transition: background-color 0.16s ease;
 }
 .svc-mini-search-btn svg { width: 16px; height: 16px; }
-.svc-mini-search-btn:hover { background: #001b5e; }
+.svc-mini-search-btn:hover { background: var(--svc-navy-deep); }
 
 .svc-mini-results {
   position: fixed;
@@ -404,19 +398,19 @@ body > pre, body > code, body > .template-name, body > .editor-label { display: 
   overflow-y: auto;
   background: #ffffff;
   border-radius: 16px;
-  border: 1px solid #e5eaf0;
+  border: 1px solid var(--svc-line);
   box-shadow: 0 16px 40px rgba(15, 33, 80, 0.16);
   text-align: left;
 }
 .svc-mr-group-header {
   display: flex; align-items: center; gap: 8px;
   padding: 12px 16px 6px;
-  border-bottom: 0.5px solid #e5eaf0;
+  border-bottom: 0.5px solid var(--svc-line);
 }
-.svc-mr-group-header.svc-mr-docs { border-top: 0.5px solid #e5eaf0; background: #fcfcfd; }
+.svc-mr-group-header.svc-mr-docs { border-top: 0.5px solid var(--svc-line); background: #fcfcfd; }
 .svc-mr-group-title { font-size: 11px; font-weight: 600; letter-spacing: 0.6px; text-transform: uppercase; }
-.svc-mr-services .svc-mr-group-title { color: #09349d; }
-.svc-mr-docs .svc-mr-group-title { color: #09349d; }
+.svc-mr-services .svc-mr-group-title { color: var(--svc-navy); }
+.svc-mr-docs .svc-mr-group-title { color: var(--svc-navy); }
 .svc-mr-group-count { font-size: 11px; color: #9aa1ad; }
 .svc-mr-item {
   display: flex; align-items: center; gap: 12px;
@@ -425,30 +419,30 @@ body > pre, body > code, body > .template-name, body > .editor-label { display: 
   transition: background-color 0.14s ease;
 }
 .svc-mr-item:hover, .svc-mr-item.svc-mr-active { background: #f5f8ff; }
-.svc-mr-item.svc-mr-service { border-left: 3px solid #09349d; }
+.svc-mr-item.svc-mr-service { border-left: 3px solid var(--svc-navy); }
 .svc-mr-item.svc-mr-doc { border-left: 3px solid #c9ced8; }
 .svc-mr-icon {
   width: 32px; height: 32px; flex-shrink: 0;
   display: flex; align-items: center; justify-content: center;
   border-radius: 8px;
 }
-.svc-mr-service .svc-mr-icon { background: #e6f5fc; color: #09349d; }
+.svc-mr-service .svc-mr-icon { background: var(--svc-tint); color: var(--svc-navy); }
 .svc-mr-doc .svc-mr-icon { background: #f1f3f7; color: #6b7280; }
 .svc-mr-icon svg { width: 17px; height: 17px; }
 .svc-mr-text { flex: 1; min-width: 0; }
 .svc-mr-title, .svc-mr-sub {
   display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.svc-mr-title { font-size: 13.5px; color: #252729; text-decoration: none; }
-.svc-mr-sub { font-size: 12px; color: #959ba3; }
+.svc-mr-title { font-size: 13.5px; color: var(--svc-ink); text-decoration: none; }
+.svc-mr-sub { font-size: 12px; color: var(--svc-gray-soft); }
 .svc-mr-badge { flex-shrink: 0; font-size: 10.5px; font-weight: 600; padding: 3px 9px; border-radius: 1000px; }
-.svc-mr-service .svc-mr-badge { color: #09349d; background: #e6f5fc; }
-.svc-mr-doc .svc-mr-badge { color: #6b7280; background: #e5eaf0; }
-.svc-mr-empty, .svc-mr-loading { padding: 16px; font-size: 13px; color: #959ba3; text-align: center; }
+.svc-mr-service .svc-mr-badge { color: var(--svc-navy); background: var(--svc-tint); }
+.svc-mr-doc .svc-mr-badge { color: #6b7280; background: var(--svc-line); }
+.svc-mr-empty, .svc-mr-loading { padding: 16px; font-size: 13px; color: var(--svc-gray-soft); text-align: center; }
 .svc-mr-footer {
   display: block; padding: 11px 16px;
-  border-top: 0.5px solid #e5eaf0;
-  font-size: 12.5px; font-weight: 500; color: #09349d;
+  border-top: 0.5px solid var(--svc-line);
+  font-size: 12.5px; font-weight: 500; color: var(--svc-navy);
   text-align: center; text-decoration: none;
 }
 .svc-mr-footer:hover { background: #f5f8ff; }

--- a/styles/_svc-tokens.scss
+++ b/styles/_svc-tokens.scss
@@ -46,3 +46,18 @@ html body .header .search-wrapper {
 .svc-empty-hidden {
   display: none !important;
 }
+
+/* Shared skeleton-loading shimmer sweep. Used by the category/list skeleton
+   placeholders in _svc-home.scss and the item-page skeleton in
+   _svc-service-item.scss — defined once here so both @extend the same
+   gradient/animation instead of duplicating it. */
+@keyframes svcSkelShimmer {
+  from { background-position: 200% 0; }
+  to   { background-position: -200% 0; }
+}
+
+%svc-skel-shimmer {
+  background: linear-gradient(100deg, var(--svc-line) 30%, #f6f8fc 50%, var(--svc-line) 70%);
+  background-size: 200% 100%;
+  animation: svcSkelShimmer 1.3s ease-in-out infinite;
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,6 +1,7 @@
 @import "normalize";
 @import "variables";
 @import "mixins";
+@import "fonts";
 @import "base";
 @import "buttons";
 @import "split_button";

--- a/templates/document_head.hbs
+++ b/templates/document_head.hbs
@@ -2,46 +2,11 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
 
 <!--
-  Self-hosted Public Sans (USWDS / ARPA-H standard type). This @font-face block
-  is the one legitimate inline <style>: Zendesk serves theme fonts via the
-  {{asset}} helper, which is only available in templates (never in style.css).
-  font-display:swap avoids invisible text while the woff2 loads. Weights
-  400/500/600/700, latin + latin-ext (latin-ext covers accented names).
+  Self-hosted Public Sans (USWDS / ARPA-H standard type) and Poppins (NEXUS
+  display type) @font-face declarations now live in styles/_fonts.scss,
+  referenced via Zendesk's $assets-<filename>-<ext> asset variable
+  convention (see zass.mjs) instead of an inline <style> block here.
 -->
-<style>
-  {{!-- 400 --}}
-  @font-face { font-family: "Public Sans"; font-style: normal; font-weight: 400; font-display: swap; src: url("{{asset 'public-sans-400-latin_ext.woff2'}}") format("woff2"); unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
-  @font-face { font-family: "Public Sans"; font-style: normal; font-weight: 400; font-display: swap; src: url("{{asset 'public-sans-400-latin.woff2'}}") format("woff2"); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
-  {{!-- 500 --}}
-  @font-face { font-family: "Public Sans"; font-style: normal; font-weight: 500; font-display: swap; src: url("{{asset 'public-sans-500-latin_ext.woff2'}}") format("woff2"); unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
-  @font-face { font-family: "Public Sans"; font-style: normal; font-weight: 500; font-display: swap; src: url("{{asset 'public-sans-500-latin.woff2'}}") format("woff2"); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
-  {{!-- 600 --}}
-  @font-face { font-family: "Public Sans"; font-style: normal; font-weight: 600; font-display: swap; src: url("{{asset 'public-sans-600-latin_ext.woff2'}}") format("woff2"); unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
-  @font-face { font-family: "Public Sans"; font-style: normal; font-weight: 600; font-display: swap; src: url("{{asset 'public-sans-600-latin.woff2'}}") format("woff2"); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
-  {{!-- 700 --}}
-  @font-face { font-family: "Public Sans"; font-style: normal; font-weight: 700; font-display: swap; src: url("{{asset 'public-sans-700-latin_ext.woff2'}}") format("woff2"); unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
-  @font-face { font-family: "Public Sans"; font-style: normal; font-weight: 700; font-display: swap; src: url("{{asset 'public-sans-700-latin.woff2'}}") format("woff2"); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
-</style>
-
-<!--
-  Self-hosted Poppins (NEXUS display type). NEXUS uses Poppins for Display + h1/h2;
-  Public Sans (above) covers h3-h6, body, and action text. Same {{asset}} + swap
-  rationale as the Public Sans block.
--->
-<style>
-  {{!-- 400 --}}
-  @font-face { font-family: "Poppins"; font-style: normal; font-weight: 400; font-display: swap; src: url("{{asset 'poppins-400-latin_ext.woff2'}}") format("woff2"); unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
-  @font-face { font-family: "Poppins"; font-style: normal; font-weight: 400; font-display: swap; src: url("{{asset 'poppins-400-latin.woff2'}}") format("woff2"); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
-  {{!-- 500 --}}
-  @font-face { font-family: "Poppins"; font-style: normal; font-weight: 500; font-display: swap; src: url("{{asset 'poppins-500-latin_ext.woff2'}}") format("woff2"); unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
-  @font-face { font-family: "Poppins"; font-style: normal; font-weight: 500; font-display: swap; src: url("{{asset 'poppins-500-latin.woff2'}}") format("woff2"); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
-  {{!-- 600 --}}
-  @font-face { font-family: "Poppins"; font-style: normal; font-weight: 600; font-display: swap; src: url("{{asset 'poppins-600-latin_ext.woff2'}}") format("woff2"); unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
-  @font-face { font-family: "Poppins"; font-style: normal; font-weight: 600; font-display: swap; src: url("{{asset 'poppins-600-latin.woff2'}}") format("woff2"); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
-  {{!-- 700 --}}
-  @font-face { font-family: "Poppins"; font-style: normal; font-weight: 700; font-display: swap; src: url("{{asset 'poppins-700-latin_ext.woff2'}}") format("woff2"); unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
-  @font-face { font-family: "Poppins"; font-style: normal; font-weight: 700; font-display: swap; src: url("{{asset 'poppins-700-latin.woff2'}}") format("woff2"); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
-</style>
 
 <!-- Make the translated search clear button label available for use in JS -->
 <!-- See buildClearSearchButton() in script.js -->

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -3,19 +3,11 @@
 
 <section id="main-content" class="section hero">
   <div class="hero-inner">
-    {{!-- <h2 class="visibility-hidden">{{ t 'search' }}</h2>
-    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
-      <circle cx="4.5" cy="4.5" r="4" fill="none" stroke="currentColor"/>
-      <path stroke="currentColor" stroke-linecap="round" d="M11 11L7.5 7.5"/>
-    </svg>
-    {{search submit=false instant=settings.instant_search class='search search-full'}}
-    --}}
    {{#if signed_in}}
     <div class="centered-buttons">
-		  <span class="item">{{#link 'new_request' class='submit-a-request'}}Report an issue{{/link}}</span>
-      <!-- <span class="item submit-a-request"><a href="https://arpah1746463021.zendesk.com/hc/en-us/services">Services</a></span> -->
+      <span class="item">{{link 'new_request' class='submit-a-request'}}</span>
     </div>
-   {{/if}}     
+   {{/if}}
 </section>
 
 {{#unless signed_in}}

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -287,26 +287,5 @@
   {{pagination}}
 </div>
 
-{{!-- Wire the pink button to submit the native search --}}
-<script>
-/* Finds the input in the pill and submits its form, matching native
-   behavior exactly. */
-(function () {
-  var btn = document.getElementById('svc-search-pill-btn');
-  if (!btn) return;
-  var pill = btn.closest('.svc-search-pill');
-  if (!pill) return;
-  btn.addEventListener('click', function () {
-    var input = pill.querySelector('input[type="search"], input[type="text"], input:not([type])');
-    if (!input) return;
-    var form = input.form || input.closest('form');
-    if (form) {
-      if (typeof form.requestSubmit === 'function') form.requestSubmit();
-      else form.submit();
-    } else {
-      input.focus();
-      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true }));
-    }
-  });
-})();
-</script>
+{{!-- Pink search-pill button submit wiring now lives in src/domFixups.js
+      (bundled into script.js). Do not re-add it inline. --}}

--- a/templates/service_list_page.hbs
+++ b/templates/service_list_page.hbs
@@ -150,66 +150,54 @@
     console.warn("Service catalog module unavailable:", e);
     const main = document.getElementById("service-catalog-main-content");
     if (main) {
-      const hcBase = (location.pathname.match(/^\/hc\/[^/]+/) || ['/hc/en-us'])[0];
-      main.innerHTML =
-        '<p class="svc-catalog-fallback">View the full ' +
-        '<a href="' + hcBase + '/services">Service Catalog</a>.</p>';
+      const hcBase = (location.pathname.match(/^\/hc\/[^/]+/) || ["/hc/en-us"])[0];
+      // Built via DOM APIs (not innerHTML string concatenation) so hcBase —
+      // derived from location.pathname — can never be interpreted as markup.
+      const fallback = document.createElement("p");
+      fallback.className = "svc-catalog-fallback";
+      fallback.append("View the full ");
+      const link = document.createElement("a");
+      link.href = `${hcBase}/services`;
+      link.textContent = "Service Catalog";
+      fallback.append(link, ".");
+      main.replaceChildren(fallback);
     }
   }
 </script>
 
-<!-- Personalized time-based greeting in the hero. -->
+<!-- Personalized time-based greeting in the hero. Name-resolution fetch is
+     shared with service_page.hbs via src/svcGreeting.js
+     (window.svcFetchFirstName); the fade-in timing below is page-specific. -->
 <script>
   (function () {
-    const title = document.getElementById('svc-list-greeting');
     const nameEl = document.getElementById('svc-list-greeting-name');
+    if (!nameEl) return;
 
-    const hour = new Date().getHours();
-    const timeGreeting = hour < 12 ? 'Good morning' : hour < 17 ? 'Good afternoon' : 'Good evening';
-
-    const looksLikeAlias = (v) => {
-      if (!v) return true;
-      const s = String(v).trim();
-      if (!s) return true;
-      if (s.indexOf('@') !== -1) return true;
-      if (/^[a-z0-9._-]+$/.test(s) && s.indexOf(' ') === -1) return true;
-      return false;
-    };
-
-    const firstNameOf = (name) => {
-      const s = String(name || '').trim();
-      if (!s) return '';
-      if (s.indexOf(',') !== -1) {
-        const parts = s.split(',').map(p => p.trim()).filter(Boolean);
-        if (parts.length >= 2) return parts[1].split(/\s+/)[0];
-      }
-      return s.split(/\s+/)[0];
-    };
-
-    const setGreeting = (name) => {
-      if (!nameEl) return;
-      const first = firstNameOf(name);
+    function setGreeting(first) {
       if (!first) return;
       const text = `, ${first}`;
       if ((nameEl.textContent || '') === text && nameEl.classList.contains('svc-name-in')) return;
       nameEl.textContent = text;
       requestAnimationFrame(() => nameEl.classList.add('svc-name-in'));
-    };
+    }
 
-    fetch('/api/v2/users/me.json', { headers: { Accept: 'application/json' }, credentials: 'same-origin' })
-      .then(r => r.ok ? r.json() : null)
-      .then(d => {
-        const u = d && d.user;
-        if (!u) return;
-        const candidates = [
-          u.name,
-          u.details && u.details.name,
-          u.user_fields && (u.user_fields.full_name || u.user_fields.preferred_name || u.user_fields.first_name)
-        ];
-        const realName = candidates.find(c => !looksLikeAlias(c)) || u.name;
-        if (realName) setGreeting(realName);
-      })
-      .catch(() => {});
+    // script.js (which defines window.svcFetchFirstName) is a classic script
+    // whose load order relative to this inline block isn't guaranteed, so
+    // poll briefly instead of assuming it has already run.
+    function tryFetch() {
+      if (typeof window.svcFetchFirstName === 'function') {
+        window.svcFetchFirstName(setGreeting);
+        return true;
+      }
+      return false;
+    }
+    if (!tryFetch()) {
+      let attempts = 0;
+      const iv = setInterval(() => {
+        attempts++;
+        if (tryFetch() || attempts > 100) clearInterval(iv);
+      }, 20);
+    }
   })();
 </script>
 
@@ -248,239 +236,63 @@
   })();
 </script>
 
-<!-- Catalog enhancements: tooltips, category text, search removal. -->
-<script>
-  (function () {
-    const main = document.getElementById('service-catalog-main-content');
-    if (!main) return;
-
-    const safeClosest = (el, sel) => (el && el.nodeType === 1 && typeof el.closest === 'function') ? el.closest(sel) : null;
-    const inSidebar = el => !!safeClosest(el, '[data-test-id^="sidebar-category"]');
-
-    const tip = document.createElement('div');
-    tip.className = 'svc-tooltip';
-    tip.setAttribute('role', 'tooltip');
-    tip.style.left = '-9999px';
-    tip.style.top = '-9999px';
-    document.body.appendChild(tip);
-    let hideTimer = null;
-
-    function getCard(el) {
-      if (!el || el.nodeType !== 1) return null;
-      if (inSidebar(el)) return null;
-      const card = safeClosest(el, 'a[href*="/services/"]') ||
-                   safeClosest(el, '[data-testid="service-catalog-list-item-container"]');
-      if (!card || inSidebar(card)) return null;
-      if (!safeClosest(card, 'a[href*="/services/"]') && !card.querySelector('a[href*="/services/"]')) return null;
-      return card;
-    }
-    function findDescEl(card) {
-      if (!card || inSidebar(card) || typeof card.querySelectorAll !== 'function') return null;
-      const leaves = Array.from(card.querySelectorAll('div, p, span')).filter(el =>
-        el && !el.querySelector('a, h1, h2, h3, h4, h5, h6, svg, img, button, div, p, span') &&
-        (el.textContent || '').trim().length > 0
-      );
-      if (leaves.length < 2) return null;
-      const heading = card.querySelector('h1,h2,h3,h4,h5,h6');
-      const titleText = heading ? heading.textContent.trim() : leaves[0].textContent.trim();
-      return leaves.find(l => { const t = l.textContent.trim(); return t && t !== titleText; }) || null;
-    }
-    function descText(card) {
-      const el = findDescEl(card);
-      if (!el) return '';
-      const t = el.textContent.trim();
-      if (/^\d+$/.test(t)) return '';
-      return t;
-    }
-
-    function hideDescriptions() {
-      main.querySelectorAll('a[href*="/services/"], [class*="card"], [class*="Card"]').forEach(card => {
-        if (inSidebar(card)) return;
-        const el = findDescEl(card);
-        if (el && !el.classList.contains('svc-desc-hidden')) el.classList.add('svc-desc-hidden');
-      });
-    }
-    function positionTip(card) {
-      const rect = card.getBoundingClientRect();
-      tip.style.maxWidth = Math.max(180, Math.min(240, rect.width + 20)) + 'px';
-      const t = tip.getBoundingClientRect(), gap = 8;
-      let left = Math.min(Math.max(rect.left, 12), window.innerWidth - t.width - 12);
-      tip.style.setProperty('--svc-arrow-left', Math.max(10, Math.min(t.width - 18, (rect.left + rect.width / 2) - left - 4)) + 'px');
-      let top;
-      if (window.innerHeight - rect.bottom > t.height + gap + 12) { top = rect.bottom + gap; tip.classList.add('svc-tooltip-below'); tip.classList.remove('svc-tooltip-above'); }
-      else { top = rect.top - t.height - gap; tip.classList.add('svc-tooltip-above'); tip.classList.remove('svc-tooltip-below'); }
-      tip.style.left = Math.round(left) + 'px';
-      tip.style.top  = Math.round(top) + 'px';
-    }
-    function showTip(card) {
-      if (!card || inSidebar(card)) return;
-      const d = descText(card);
-      if (!d) return;
-      clearTimeout(hideTimer);
-      tip.textContent = d;
-      tip.style.left = '-9999px'; tip.style.top = '0px';
-      requestAnimationFrame(() => { positionTip(card); requestAnimationFrame(() => tip.classList.add('svc-tooltip-visible')); });
-    }
-    function hideTip() { tip.classList.remove('svc-tooltip-visible'); hideTimer = setTimeout(() => { tip.style.left = '-9999px'; }, 200); }
-
-    let userInteracted = false;
-    ['pointerdown', 'keydown', 'mousemove'].forEach(evt =>
-      window.addEventListener(evt, () => { userInteracted = true; }, { once: true, passive: true })
-    );
-
-    main.addEventListener('mouseover', e => { const c = getCard(e.target); if (c) showTip(c); });
-    main.addEventListener('mouseout',  e => { const c = getCard(e.target), to = e.relatedTarget ? getCard(e.relatedTarget) : null; if (c && c !== to) hideTip(); });
-    main.addEventListener('focusin',   e => { if (!userInteracted) return; const c = getCard(e.target); if (c) showTip(c); });
-    main.addEventListener('focusout',  e => { const c = getCard(e.target), to = e.relatedTarget ? getCard(e.relatedTarget) : null; if (c && c !== to) hideTip(); });
-    window.addEventListener('scroll', hideTip, { passive: true });
-    window.addEventListener('resize', hideTip);
-
-    function removeCatalogSearch() {
-      const fields = main.querySelectorAll(
-        'input[type="search"], input[type="text"], input:not([type]), [role="searchbox"], [contenteditable="true"]'
-      );
-      fields.forEach(field => {
-        if (inSidebar(field)) return;
-        const wrap = safeClosest(field, 'form[role="search"]') ||
-                     safeClosest(field, '[class*="search"]') ||
-                     safeClosest(field, '[class*="Search"]') ||
-                     field.parentElement;
-        if (wrap && wrap !== main &&
-            !wrap.querySelector('a[href*="/services/"]') &&
-            !wrap.querySelector('[data-test-id^="sidebar-category"]')) {
-          wrap.remove();
-        } else {
-          field.remove();
-        }
-      });
-    }
-
-    const DESCRIPTIONS = {
-      "all services": "Browse every service available from the Service Desk, or pick a category to narrow things down.",
-      "accessibility": "Request accessibility reviews and support to ensure content and tools work for everyone.",
-      "account services": "Manage your accounts, access, passwords, and identity credentials like PIV cards.",
-      "apps & tools": "Get access to, install, or troubleshoot the software applications and tools you use day to day.",
-      "aurora": "Support and requests related to the AURORA platform.",
-      "collaboration": "Tools and support for working together — chat, meetings, file sharing, and team spaces.",
-      "devices & equipment": "Request, return, or get help with laptops, peripherals, and other hardware.",
-      "event and room support": "Book and get technical support for conference rooms, events, and presentations.",
-      "get help": "Report an issue or get support — outages, hardware and software problems, lost devices, security incidents, and more.",
-      "grace": "Support and requests related to the GRACE platform.",
-      "help me learn": "Find training, certifications, and learning resources to build your skills."
-    };
-    const DEFAULT_DESC = "Browse the services in this category and submit a request to the Service Desk.";
-    function applyCategoryDescription() {
-      const heading = Array.from(main.querySelectorAll('h1, h2, h3')).find(h => !inSidebar(h));
-      if (!heading) return;
-      const text = DESCRIPTIONS[(heading.textContent || '').trim().toLowerCase()] || DEFAULT_DESC;
-      let desc = heading.parentElement ? heading.parentElement.querySelector(':scope > .svc-cat-description') : null;
-      if (!desc) { desc = document.createElement('p'); desc.className = 'svc-cat-description'; heading.insertAdjacentElement('afterend', desc); }
-      if (desc.textContent !== text) desc.textContent = text;
-    }
-
-    function enhance() {
-      [removeCatalogSearch, hideDescriptions, applyCategoryDescription]
-        .forEach(fn => { try { fn(); } catch (e) { console.warn('enhance step failed:', e); } });
-    }
-    enhance();
-    new MutationObserver(enhance).observe(main, { childList: true, subtree: true });
-  })();
-</script>
-
-<!-- Category-swap skeleton hiding -->
-<script>
-  (function () {
-    const main = document.getElementById('service-catalog-main-content');
-    if (!main) return;
-
-    const inSidebar = (el) =>
-      !!(el && el.nodeType === 1 && typeof el.closest === 'function' &&
-         el.closest('[data-test-id^="sidebar-category"]'));
-
-    function tagSkeletons() {
-      const cells = main.querySelectorAll(
-        '[data-testid="service-catalog-list-item-container"], [data-garden-id="grid.col"]'
-      );
-      cells.forEach(cell => {
-        if (cell.nodeType !== 1) return;
-        if (inSidebar(cell)) return;
-        const link = cell.querySelector('a[href*="/services/"]');
-        const isSkeleton = !link || (link.textContent || '').trim().length === 0;
-        cell.classList.toggle('svc-skeleton', isSkeleton);
-      });
-    }
-
-    try { tagSkeletons(); } catch (e) { console.warn('skeleton tag failed:', e); }
-    new MutationObserver(() => {
-      try { tagSkeletons(); } catch (e) { console.warn('skeleton tag failed:', e); }
-    }).observe(main, { childList: true, subtree: true });
-  })();
-</script>
+<!-- Catalog enhancements (tooltips, category text, search removal) and
+     category-swap skeleton hiding now live in src/svcCatalogEnhancements.js
+     (bundled into script.js) since neither depends on server-rendered
+     Curlybars data. Do not re-add them inline. -->
 
 <!-- Catalog reveal controller. The hero is static, fully-styled markup and is
      visible immediately (no hide-by-default guard); only the async service
      catalog is gated. This swaps the skeleton for the real catalog
      (.svc-cat-ready) once it is complete. (.svc-ready is now a harmless no-op,
      kept only so existing callers don't need touching.)
-     SAFETY: 6s JS hard cap + 6.5s CSS failsafe + instant reveal on bfcache. -->
+     Shared reveal-on-complete controller lives in src/svcReveal.js
+     (window.initSvcRevealOnComplete), consistent with service_page.hbs's
+     form-skeleton reveal. SAFETY: 6s JS hard cap + 6.5s CSS failsafe +
+     instant reveal on bfcache. -->
 <script>
   (function () {
     var root = document.documentElement;
-    var main = document.getElementById('service-catalog-main-content');
-    var skel = document.getElementById('svc-catalog-skeleton');
 
     // Reveal the hero immediately once the page is interactive — the hero is
     // our own fully-styled markup, so there's no reason to hold it for the
     // catalog. Holding only the catalog behind its skeleton avoids the flash
     // while keeping the greeting snappy.
-    function revealPage() { root.classList.add('svc-ready'); }
-
-    var done = false;
-    function showCatalog() {
-      if (done) return;
-      done = true;
-      root.classList.add('svc-cat-ready');
-      if (skel) {
-        skel.classList.add('svc-cat-skel-hide');
-        setTimeout(function () { if (skel && skel.parentNode) skel.parentNode.removeChild(skel); }, 320);
-      }
-    }
-
-    // Reveal the hero as soon as styles are applied (this script runs after
-    // the stylesheet in the body, so styling is guaranteed here).
+    function revealHero() { root.classList.add('svc-ready'); }
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', revealPage);
+      document.addEventListener('DOMContentLoaded', revealHero);
     } else {
-      revealPage();
+      revealHero();
     }
+    window.addEventListener('pageshow', function (e) { if (e.persisted) revealHero(); });
 
-    if (!main) { revealPage(); return; }
-
-    // "Complete" = the catalog has real service links rendered.
-    function catalogIsComplete() {
-      return !!main.querySelector('a[href*="/services/"]');
+    var config = {
+      targetId: 'service-catalog-main-content',
+      skeletonId: 'svc-catalog-skeleton',
+      skeletonHideClass: 'svc-cat-skel-hide',
+      readyClasses: ['svc-cat-ready'],
+      // "Complete" = the catalog has real service links rendered.
+      isComplete: function (main) {
+        return !!main.querySelector('a[href*="/services/"]');
+      }
+    };
+    // script.js (which defines window.initSvcRevealOnComplete) is a classic
+    // script whose load order relative to this inline block isn't
+    // guaranteed, so poll briefly instead of assuming it has already run.
+    function tryInit() {
+      if (typeof window.initSvcRevealOnComplete === 'function') {
+        window.initSvcRevealOnComplete(config);
+        return true;
+      }
+      return false;
     }
-
-    var SETTLE_MS = 400;
-    var settleTimer = null;
-    function armSettle() {
-      if (settleTimer) clearTimeout(settleTimer);
-      settleTimer = setTimeout(showCatalog, SETTLE_MS);
+    if (!tryInit()) {
+      var attempts = 0;
+      var iv = setInterval(function () {
+        attempts++;
+        if (tryInit() || attempts > 100) clearInterval(iv);
+      }, 20);
     }
-    function check() { if (!done && catalogIsComplete()) armSettle(); }
-
-    check();
-    var mo = new MutationObserver(check);
-    mo.observe(main, { childList: true, subtree: true });
-    (function stop() { if (done) mo.disconnect(); else setTimeout(stop, 300); })();
-
-    // Hard failsafe: reveal everything no later than 6s regardless.
-    setTimeout(function () { revealPage(); showCatalog(); }, 6000);
-
-    // bfcache restore: already rendered, reveal instantly.
-    window.addEventListener('pageshow', function (e) {
-      if (e.persisted) { revealPage(); showCatalog(); }
-    });
   })();
 </script>
 {{/if}}

--- a/templates/service_page.hbs
+++ b/templates/service_page.hbs
@@ -127,7 +127,7 @@
           <ul class="svc-card-list">
             <li>You'll receive an email confirmation with your request or ticket number.</li>
             <li>You can reply to that email at any time to add updates or attachments.</li>
-            <li>You can track progress in the Service Hub under <strong>My requests</strong>.</li>
+            <li>You can track progress in the Service Hub under <strong>{{t 'my_requests'}}</strong>.</li>
           </ul>
         </section>
         <section class="svc-card">
@@ -208,7 +208,9 @@
   })();
 </script>
 
-{{!-- Personalized greeting --}}
+{{!-- Personalized greeting. Name-resolution fetch is shared with
+     service_list_page.hbs via src/svcGreeting.js (window.svcFetchFirstName);
+     the reveal timing/text-formatting below is specific to this page. --}}
 <script>
   (function () {
     var title = document.getElementById('svc-greeting');
@@ -216,27 +218,7 @@
 
     function reveal() { title.classList.add('svc-greeting-ready'); }
 
-    function looksLikeAlias(v) {
-      if (!v) return true;
-      var s = String(v).trim();
-      if (!s) return true;
-      if (s.indexOf('@') !== -1) return true;
-      if (/^[a-z0-9._-]+$/.test(s) && s.indexOf(' ') === -1) return true;
-      return false;
-    }
-
-    function firstNameOf(name) {
-      var s = String(name || '').trim();
-      if (!s) return '';
-      if (s.indexOf(',') !== -1) {
-        var parts = s.split(',').map(function (p) { return p.trim(); }).filter(Boolean);
-        if (parts.length >= 2) return parts[1].split(/\s+/)[0];
-      }
-      return s.split(/\s+/)[0];
-    }
-
-    function setGreeting(name) {
-      var first = firstNameOf(name);
+    function setGreeting(first) {
       title.textContent = first ? ('How can we help, ' + first + '?') : 'How can we help?';
     }
 
@@ -248,74 +230,64 @@
       reveal();
     }, 2400);
 
-    function finish(name) {
+    function finish(first) {
       if (revealed) return;
       revealed = true;
       clearTimeout(revealTimer);
-      setGreeting(name || '');
+      setGreeting(first || '');
       reveal();
     }
 
-    fetch('/api/v2/users/me.json', { headers: { Accept: 'application/json' }, credentials: 'same-origin' })
-      .then(function (r) { return r.ok ? r.json() : null; })
-      .then(function (d) {
-        var u = d && d.user;
-        if (!u) { finish(''); return; }
-        var candidates = [
-          u.name,
-          u.details && u.details.name,
-          u.user_fields && (u.user_fields.full_name || u.user_fields.preferred_name || u.user_fields.first_name)
-        ];
-        var realName = candidates.find(function (c) { return !looksLikeAlias(c); }) || u.name;
-        finish(realName);
-      })
-      .catch(function () { finish(''); });
+    // script.js (which defines window.svcFetchFirstName) is a classic script
+    // whose load order relative to this inline block isn't guaranteed, so
+    // poll briefly instead of assuming it has already run.
+    function tryFetch() {
+      if (typeof window.svcFetchFirstName === 'function') {
+        window.svcFetchFirstName(finish);
+        return true;
+      }
+      return false;
+    }
+    if (!tryFetch()) {
+      var attempts = 0;
+      var iv = setInterval(function () {
+        attempts++;
+        if (tryFetch() || attempts > 100) clearInterval(iv);
+      }, 20);
+    }
   })();
 </script>
 
-{{!-- Swap skeleton -> real form once complete --}}
+{{!-- Swap skeleton -> real form once complete. Shared reveal-on-complete
+     controller lives in src/svcReveal.js (window.initSvcRevealOnComplete),
+     consistent with service_list_page.hbs's catalog reveal. --}}
 <script>
   (function () {
-    var root = document.documentElement;
-    var form = document.getElementById('service-catalog-item');
-    var skel = document.getElementById('svc-form-skeleton');
-    if (!form) return;
-
-    var done = false;
-    function showForm() {
-      if (done) return;
-      done = true;
-      root.classList.add('svc-form-ready');
-      if (skel) {
-        skel.classList.add('svc-skel-hide');
-        setTimeout(function () { if (skel && skel.parentNode) skel.parentNode.removeChild(skel); }, 320);
+    var config = {
+      targetId: 'service-catalog-item',
+      skeletonId: 'svc-form-skeleton',
+      readyClasses: ['svc-form-ready'],
+      isComplete: function (form) {
+        return !!form.querySelector('input, textarea, select, button[type="submit"], [role="textbox"]');
       }
+    };
+    // script.js (which defines window.initSvcRevealOnComplete) is a classic
+    // script whose load order relative to this inline block isn't
+    // guaranteed, so poll briefly instead of assuming it has already run.
+    function tryInit() {
+      if (typeof window.initSvcRevealOnComplete === 'function') {
+        window.initSvcRevealOnComplete(config);
+        return true;
+      }
+      return false;
     }
-
-    function formIsComplete() {
-      return !!form.querySelector('input, textarea, select, button[type="submit"], [role="textbox"]');
+    if (!tryInit()) {
+      var attempts = 0;
+      var iv = setInterval(function () {
+        attempts++;
+        if (tryInit() || attempts > 100) clearInterval(iv);
+      }, 20);
     }
-
-    var SETTLE_MS = 400;
-    var settleTimer = null;
-    function armSettle() {
-      if (settleTimer) clearTimeout(settleTimer);
-      settleTimer = setTimeout(showForm, SETTLE_MS);
-    }
-
-    function check() {
-      if (done) return;
-      if (formIsComplete()) armSettle();
-    }
-
-    check();
-    var mo = new MutationObserver(check);
-    mo.observe(form, { childList: true, subtree: true });
-    (function stop() { if (done) mo.disconnect(); else setTimeout(stop, 300); })();
-
-    setTimeout(showForm, 6000);
-
-    window.addEventListener('pageshow', function (e) { if (e.persisted) showForm(); });
   })();
 </script>
 
@@ -340,14 +312,34 @@
     fab.className = 'svc-training-fab';
     fab.href = window.svcSafeHref ? window.svcSafeHref(trainingUrl, '#') : trainingUrl;
     fab.setAttribute('aria-label', trainingLabel);
-    fab.innerHTML =
-      '<span class="svc-training-fab-icon" aria-hidden="true">' +
-        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
-          '<path d="M22 10L12 5 2 10l10 5 10-5z"></path>' +
-          '<path d="M6 12v5c0 1 2.5 2.5 6 2.5s6-1.5 6-2.5v-5"></path>' +
-        '</svg>' +
-      '</span>' +
-      '<span class="svc-training-fab-label">' + trainingLabel + '</span>';
+
+    // Built via DOM/SVG APIs (not an innerHTML string) to avoid the
+    // markup-via-string-concatenation pattern used elsewhere in this file.
+    var SVG_NS = 'http://www.w3.org/2000/svg';
+    var iconWrap = document.createElement('span');
+    iconWrap.className = 'svc-training-fab-icon';
+    iconWrap.setAttribute('aria-hidden', 'true');
+    var svg = document.createElementNS(SVG_NS, 'svg');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('fill', 'none');
+    svg.setAttribute('stroke', 'currentColor');
+    svg.setAttribute('stroke-width', '2');
+    svg.setAttribute('stroke-linecap', 'round');
+    svg.setAttribute('stroke-linejoin', 'round');
+    var capPath = document.createElementNS(SVG_NS, 'path');
+    capPath.setAttribute('d', 'M22 10L12 5 2 10l10 5 10-5z');
+    var basePath = document.createElementNS(SVG_NS, 'path');
+    basePath.setAttribute('d', 'M6 12v5c0 1 2.5 2.5 6 2.5s6-1.5 6-2.5v-5');
+    svg.appendChild(capPath);
+    svg.appendChild(basePath);
+    iconWrap.appendChild(svg);
+
+    var labelEl = document.createElement('span');
+    labelEl.className = 'svc-training-fab-label';
+    labelEl.textContent = trainingLabel;
+
+    fab.appendChild(iconWrap);
+    fab.appendChild(labelEl);
     document.body.appendChild(fab);
 
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;

--- a/translations/ar.json
+++ b/translations/ar.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "تقتصر نتائج البحث على الموضوع الحالي للمستخدم",
   "scoped_community_search_label": "البحث في إطار مجال في المجتمع",
   "scoped_knowledge_base_search_description": "تقتصر نتائج البحث على الفئة الحالية للمستخدم",
-  "scoped_knowledge_base_search_label": "البحث في إطار مجال في قاعدة المعرفة",
   "scoped_knowledge_base_search_label_v2": "بحث محدد النطاق في مركز المساعدة",
   "search_group_label": "إعدادات البحث",
   "section_page_group_label": "عناصر صفحة الجزء",

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Резултатите от търсенето са ограничени до темата, в която е потребителят",
   "scoped_community_search_label": "Филтрирано търсене в общността",
   "scoped_knowledge_base_search_description": "Резултатите от търсенето са ограничени до категорията, в която е потребителят",
-  "scoped_knowledge_base_search_label": "Филтрирано търсене в базата знания",
   "scoped_knowledge_base_search_label_v2": "Търсен обхват в помощния център",
   "search_group_label": "Настройки за търсене",
   "section_page_group_label": "Елементи на страницата на раздел",

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Omezí výsledky hledání na téma, ve kterém uživatel právě je.",
   "scoped_community_search_label": "Cílené hledání v komunitě",
   "scoped_knowledge_base_search_description": "Omezí výsledky hledání na kategorii, ve které uživatel právě je.",
-  "scoped_knowledge_base_search_label": "Cílené hledání ve znalostní bázi",
   "scoped_knowledge_base_search_label_v2": "Cílené vyhledávání v centru nápovědy",
   "search_group_label": "Nastavení hledání",
   "section_page_group_label": "Elementy stránky oddílu",

--- a/translations/da.json
+++ b/translations/da.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Søgeresultater er begrænset til det emne, som brugeren befinder sig i",
   "scoped_community_search_label": "Filtreret søgning i community",
   "scoped_knowledge_base_search_description": "Søgeresultater er begrænset til den kategori, som brugeren befinder sig i",
-  "scoped_knowledge_base_search_label": "Filtreret søgning i vidensbase",
   "scoped_knowledge_base_search_label_v2": "Filtreret søgning i hjælpecenter",
   "search_group_label": "Søgeindstillinger",
   "section_page_group_label": "Sektionssideelementer",

--- a/translations/de.json
+++ b/translations/de.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Suchergebnisse sind auf das jeweilige Thema begrenzt",
   "scoped_community_search_label": "Begrenzte Suche in Community",
   "scoped_knowledge_base_search_description": "Suchergebnisse sind auf die jeweilige Kategorie begrenzt",
-  "scoped_knowledge_base_search_label": "Begrenzte Suche in Wissensdatenbank",
   "scoped_knowledge_base_search_label_v2": "Begrenzte Suche im Help Center",
   "search_group_label": "Sucheinstellungen",
   "section_page_group_label": "Elemente auf Abschnittsseiten",

--- a/translations/el.json
+++ b/translations/el.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Τα αποτελέσματα αναζήτησης περιορίζονται στο θέμα στο οποίο βρίσκεται ο χρήστης",
   "scoped_community_search_label": "Εστιασμένη αναζήτηση στην Κοινότητα",
   "scoped_knowledge_base_search_description": "Τα αποτελέσματα αναζήτησης περιορίζονται στην κατηγορία στην οποία βρίσκεται ο χρήστης",
-  "scoped_knowledge_base_search_label": "Εστιασμένη αναζήτηση στη Γνωσιακή βάση",
   "scoped_knowledge_base_search_label_v2": "Εστιασμένη αναζήτηση στο κέντρο βοήθειας",
   "search_group_label": "Ρυθμίσεις αναζήτησης",
   "section_page_group_label": "Στοιχεία σελίδας ενοτήτων",

--- a/translations/en-ca.json
+++ b/translations/en-ca.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Search results are confined to the topic the user is in",
   "scoped_community_search_label": "Scoped search in Community",
   "scoped_knowledge_base_search_description": "Search results are confined to the category the user is in",
-  "scoped_knowledge_base_search_label": "Scoped search in Knowledge Base",
   "scoped_knowledge_base_search_label_v2": "Scoped search in help centre",
   "search_group_label": "Search settings",
   "section_page_group_label": "Section page elements",

--- a/translations/en-gb.json
+++ b/translations/en-gb.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Search results are confined to the topic the user is in",
   "scoped_community_search_label": "Scoped search in Community",
   "scoped_knowledge_base_search_description": "Search results are confined to the category the user is in",
-  "scoped_knowledge_base_search_label": "Scoped search in Knowledge Base",
   "scoped_knowledge_base_search_label_v2": "Scoped search in help centre",
   "search_group_label": "Search settings",
   "section_page_group_label": "Section page elements",

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -63,7 +63,6 @@
   "scoped_community_search_description": "Search results are confined to the topic the user is in",
   "scoped_community_search_label": "Scoped search in Community",
   "scoped_knowledge_base_search_description": "Search results are confined to the category the user is in",
-  "scoped_knowledge_base_search_label": "Scoped search in Knowledge Base",
   "scoped_knowledge_base_search_label_v2": "Scoped search in help center",
   "search_group_label": "Search settings",
   "section_page_group_label": "Section page elements",

--- a/translations/es-419.json
+++ b/translations/es-419.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Los resultados de la búsqueda se limitan al tema en el que se encuentra el usuario",
   "scoped_community_search_label": "Búsqueda filtrada en la comunidad",
   "scoped_knowledge_base_search_description": "Los resultados de la búsqueda se limitan a la categoría en la que se encuentra el usuario",
-  "scoped_knowledge_base_search_label": "Búsqueda filtrada en la base de conocimientos",
   "scoped_knowledge_base_search_label_v2": "Búsqueda filtrada en el centro de ayuda",
   "search_group_label": "Configuración de la búsqueda",
   "section_page_group_label": "Elementos de página de la sección",

--- a/translations/es-es.json
+++ b/translations/es-es.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Los resultados de la búsqueda se limitan al tema en el que se encuentra el usuario",
   "scoped_community_search_label": "Búsqueda filtrada en la comunidad",
   "scoped_knowledge_base_search_description": "Los resultados de la búsqueda se limitan a la categoría en la que se encuentra el usuario",
-  "scoped_knowledge_base_search_label": "Búsqueda filtrada en la base de conocimientos",
   "scoped_knowledge_base_search_label_v2": "Búsqueda filtrada en el centro de ayuda",
   "search_group_label": "Configuración de la búsqueda",
   "section_page_group_label": "Elementos de página de la sección",

--- a/translations/es.json
+++ b/translations/es.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Los resultados de la búsqueda se limitan al tema en el que se encuentra el usuario",
   "scoped_community_search_label": "Búsqueda filtrada en la comunidad",
   "scoped_knowledge_base_search_description": "Los resultados de la búsqueda se limitan a la categoría en la que se encuentra el usuario",
-  "scoped_knowledge_base_search_label": "Búsqueda filtrada en la base de conocimientos",
   "scoped_knowledge_base_search_label_v2": "Búsqueda filtrada en el centro de ayuda",
   "search_group_label": "Configuración de la búsqueda",
   "section_page_group_label": "Elementos de página de la sección",

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Hakutulokset rajoitetaan aiheeseen, jossa käyttäjä on",
   "scoped_community_search_label": "Suodatettu haku yhteisössä",
   "scoped_knowledge_base_search_description": "Hakutulokset rajoitetaan kategoriaan, jossa käyttäjä on",
-  "scoped_knowledge_base_search_label": "Suodatettu haku ratkaisutietokannasta",
   "scoped_knowledge_base_search_label_v2": "Suodatettu haku tukiportaalissa",
   "search_group_label": "Hakutulokset",
   "section_page_group_label": "Osio-sivun elementit",

--- a/translations/fr-ca.json
+++ b/translations/fr-ca.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Les résultats de la recherche sont limités au sujet dans lequel se trouve l’utilisateur",
   "scoped_community_search_label": "Recherche limitée dans la communauté",
   "scoped_knowledge_base_search_description": "Les résultats de la recherche sont limités à la catégorie dans laquelle se trouve l’utilisateur",
-  "scoped_knowledge_base_search_label": "Recherche limitée dans la base de connaissances",
   "scoped_knowledge_base_search_label_v2": "Recherche ciblée dans le centre d’aide",
   "search_group_label": "Paramètres de recherche",
   "section_page_group_label": "Éléments de la page de section",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Les résultats de la recherche sont limités au sujet dans lequel se trouve l’utilisateur",
   "scoped_community_search_label": "Recherche limitée dans la communauté",
   "scoped_knowledge_base_search_description": "Les résultats de la recherche sont limités à la catégorie dans laquelle se trouve l’utilisateur",
-  "scoped_knowledge_base_search_label": "Recherche limitée dans la base de connaissances",
   "scoped_knowledge_base_search_label_v2": "Recherche ciblée dans le centre d’aide",
   "search_group_label": "Paramètres de recherche",
   "section_page_group_label": "Éléments de la page de section",

--- a/translations/he.json
+++ b/translations/he.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "תוצאות החיפוש מוגבלות לנושא שהמשתמש נמצא בו",
   "scoped_community_search_label": "חיפוש מתוחם בקהילה",
   "scoped_knowledge_base_search_description": "תוצאות החיפוש מוגבלות לקטגוריה שהמשתמש נמצא בה",
-  "scoped_knowledge_base_search_label": "חיפוש מתוחם במאגר הידע",
   "scoped_knowledge_base_search_label_v2": "חיפוש מתוחם במרכז התמיכה",
   "search_group_label": "הגדרות חיפוש",
   "section_page_group_label": "רכיבי דף קטגוריית משנה",

--- a/translations/hi.json
+++ b/translations/hi.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "खोज परिणाम उस विषय तक ही सीमित हैं, जिसमें उपयोगकर्ता है",
   "scoped_community_search_label": "समुदाय में सीमित खोज",
   "scoped_knowledge_base_search_description": "खोज परिणाम उस श्रेणी तक ही सीमित हैं, जिसमें उपयोगकर्ता है",
-  "scoped_knowledge_base_search_label": "जानकारी के आधार में सीमित खोज",
   "scoped_knowledge_base_search_label_v2": "सहायता केंद्र में सीमित खोज",
   "search_group_label": "खोज सेटिंग",
   "section_page_group_label": "अनुभाग पृष्ठ तत्व",

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "A keresési eredmények azokra a témakörökre korlátozódnak, amelyekben a felhasználó megtalálható",
   "scoped_community_search_label": "Célzott keresés a közösségben",
   "scoped_knowledge_base_search_description": "A keresési eredmények azokra a kategóriákra korlátozódnak, amelyekben a felhasználó megtalálható",
-  "scoped_knowledge_base_search_label": "Célzott keresés a Tudásbázisban",
   "scoped_knowledge_base_search_label_v2": "Célzott keresés a súgóközpontban",
   "search_group_label": "Keresési beállítások",
   "section_page_group_label": "Szakaszoldal elemei",

--- a/translations/id.json
+++ b/translations/id.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Hasil pencarian dibatasi untuk topik yang dimasuki pengguna",
   "scoped_community_search_label": "Pencarian dalam cakupan di Komunitas",
   "scoped_knowledge_base_search_description": "Hasil pencarian dibatasi untuk kategori yang dimasuki pengguna",
-  "scoped_knowledge_base_search_label": "Pencarian dalam cakupan di Basis Pengetahuan",
   "scoped_knowledge_base_search_label_v2": "Pencarian yang tercakup di pusat bantuan",
   "search_group_label": "Pengaturan pencarian",
   "section_page_group_label": "Elemen halaman bagian",

--- a/translations/it.json
+++ b/translations/it.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Risultati di ricerca limitati all’argomento visualizzato dall’utente",
   "scoped_community_search_label": "Ricerca limitata nella Community",
   "scoped_knowledge_base_search_description": "Risultati di ricerca limitati alla categoria visualizzata dall’utente",
-  "scoped_knowledge_base_search_label": "Ricerca limitata nella Knowledge base",
   "scoped_knowledge_base_search_label_v2": "Ricerca con ambito nel centro assistenza",
   "search_group_label": "Impostazioni di ricerca",
   "section_page_group_label": "Elementi pagina sezione",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "検索結果はユーザーが閲覧中のトピックに限定されます",
   "scoped_community_search_label": "コミュニティの範囲限定検索",
   "scoped_knowledge_base_search_description": "検索結果はユーザーが閲覧中のカテゴリに限定されます",
-  "scoped_knowledge_base_search_label": "ナレッジベースの範囲限定検索",
   "scoped_knowledge_base_search_label_v2": "ヘルプセンター内の範囲限定検索",
   "search_group_label": "検索設定",
   "section_page_group_label": "セクションページの要素",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "검색 결과의 범위를 사용자가 속한 주제로 제한",
   "scoped_community_search_label": "커뮤니티에서만 검색",
   "scoped_knowledge_base_search_description": "검색 결과의 범위를 사용자가 속한 카테고리로 제한",
-  "scoped_knowledge_base_search_label": "지식창고에서만 검색",
   "scoped_knowledge_base_search_label_v2": "헬프 센터의 범위 지정 검색",
   "search_group_label": "검색 설정",
   "section_page_group_label": "섹션 페이지 요소",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Zoekresultaten zijn beperkt tot het onderwerp waarbinnen de gebruiker zich bevindt",
   "scoped_community_search_label": "Gefilterde zoekopdracht in community",
   "scoped_knowledge_base_search_description": "Zoekresultaten zijn beperkt tot de categorie waarbinnen de gebruiker zich bevindt",
-  "scoped_knowledge_base_search_label": "Gefilterde zoekopdracht in kennisbank",
   "scoped_knowledge_base_search_label_v2": "Zoeken met bereiken in helpcenter",
   "search_group_label": "Zoekinstellingen",
   "section_page_group_label": "Elementen op sectiepagina",

--- a/translations/no.json
+++ b/translations/no.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Søkeresultater er begrenset til emnet brukeren er i",
   "scoped_community_search_label": "Begrenset søk i Nettsamfunn",
   "scoped_knowledge_base_search_description": "Søkeresultater er begrenset til kategorien brukeren er i",
-  "scoped_knowledge_base_search_label": "Begrenset søk i Kunnskapsbase",
   "scoped_knowledge_base_search_label_v2": "Begrenset søk i kundesenter",
   "search_group_label": "Søk-innstillinger",
   "section_page_group_label": "Seksjonssideelementer",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Wyniki wyszukiwania są zawężone do tematu, w którym znajduje się użytkownik",
   "scoped_community_search_label": "Filtrowane wyszukiwanie w społeczności",
   "scoped_knowledge_base_search_description": "Wyniki wyszukiwania są zawężone do kategorii, w której znajduje się użytkownik",
-  "scoped_knowledge_base_search_label": "Filtrowane wyszukiwanie w bazie wiedzy",
   "scoped_knowledge_base_search_label_v2": "Filtrowane wyszukiwanie w centrum pomocy",
   "search_group_label": "Ustawienia wyszukiwania",
   "section_page_group_label": "Elementy strony sekcji",

--- a/translations/pt-br.json
+++ b/translations/pt-br.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Os resultados da pesquisa estão restritos ao tópico que o usuário está visitando",
   "scoped_community_search_label": "Pesquisa com escopo na Comunidade",
   "scoped_knowledge_base_search_description": "Os resultados da pesquisa estão restritos à categoria que o usuário está visitando",
-  "scoped_knowledge_base_search_label": "Pesquisa dentro do escopo na base de conhecimento",
   "scoped_knowledge_base_search_label_v2": "Pesquisa com escopo na central de ajuda",
   "search_group_label": "Configurações de pesquisa",
   "section_page_group_label": "Elementos da página da seção",

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Rezultatele căutării sunt limitate la subiectul în care se află utilizatorul",
   "scoped_community_search_label": "Căutare filtrată în Comunitate",
   "scoped_knowledge_base_search_description": "Rezultatele căutării sunt limitate la categoria în care se află utilizatorul",
-  "scoped_knowledge_base_search_label": "Căutare filtrată în Baza de cunoștințe",
   "scoped_knowledge_base_search_label_v2": "Căutare cu scop în centrul de asistență",
   "search_group_label": "Setări căutare",
   "section_page_group_label": "Elemente pagină de secțiune",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Результаты поиска ограничены темой, в которой находится пользователь",
   "scoped_community_search_label": "Ограниченный поиск в сообществе",
   "scoped_knowledge_base_search_description": "Результаты поиска ограничены категорией, в которой находится пользователь",
-  "scoped_knowledge_base_search_label": "Ограниченный поиск в базе знаний",
   "scoped_knowledge_base_search_label_v2": "Ограниченный поиск в справочном центре",
   "search_group_label": "Настройки поиска",
   "section_page_group_label": "Элементы страницы раздела",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Výsledky vyhľadávania sú obmedzené na tému, v ktorej sa nachádza používateľ",
   "scoped_community_search_label": "Obmedzený rozsah vyhľadávania v komunite",
   "scoped_knowledge_base_search_description": "Výsledky vyhľadávania sú obmedzené na kategóriu, v ktorej sa nachádza používateľ",
-  "scoped_knowledge_base_search_label": "Obmedzený rozsah vyhľadávania vo vedomostnej databáze",
   "scoped_knowledge_base_search_label_v2": "Obmedzený rozsah vyhľadávania v centre pomoci",
   "search_group_label": "Nastavenia vyhľadávania",
   "section_page_group_label": "Prvky stránky sekcií",

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Sökresultaten begränsas till det ämne användaren befinner sig i",
   "scoped_community_search_label": "Begränsad sökning i communityn",
   "scoped_knowledge_base_search_description": "Sökresultaten begränsas till den kategori användaren befinner sig i",
-  "scoped_knowledge_base_search_label": "Begränsad sökning i kunskapsbasen",
   "scoped_knowledge_base_search_label_v2": "Begränsad sökning i helpcenter",
   "search_group_label": "Sökinställningar",
   "section_page_group_label": "Element på avsnittssidan",

--- a/translations/th.json
+++ b/translations/th.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "ผลการค้นหาจะจำกัดเฉพาะหัวข้อที่ผู้ใช้สนใจ",
   "scoped_community_search_label": "ขอบเขตการค้นหาในชุมชน",
   "scoped_knowledge_base_search_description": "ผลการค้นหาจะจำกัดเฉพาะหมวดหมู่ที่ผู้ใช้สนใจ",
-  "scoped_knowledge_base_search_label": "ขอบเขตการค้นหาในฐานความรู้",
   "scoped_knowledge_base_search_label_v2": "การค้นหาตามขอบเขตในศูนย์ความช่วยเหลือ",
   "search_group_label": "การตั้งค่าการค้นหา",
   "section_page_group_label": "องค์ประกอบของหน้าหมวด",

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Arama sonuçları, kullanıcının içinde bulunduğu konuyla sınırlıdır",
   "scoped_community_search_label": "Toplulukta kapsamı belirli arama",
   "scoped_knowledge_base_search_description": "Arama sonuçları, kullanıcının içinde bulunduğu kategoriyle sınırlıdır",
-  "scoped_knowledge_base_search_label": "Bilgi Bankasında kapsamı belirli arama",
   "scoped_knowledge_base_search_label_v2": "Yardım merkezinde kapsamlı arama",
   "search_group_label": "Arama ayarları",
   "section_page_group_label": "Bölüm sayfası öğeleri",

--- a/translations/uk.json
+++ b/translations/uk.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Результати пошуку обмежені тематикою, в якій перебуває користувач",
   "scoped_community_search_label": "Масштабований пошук у спільноті",
   "scoped_knowledge_base_search_description": "Результати пошуку обмежені категорією, до якої належить користувач",
-  "scoped_knowledge_base_search_label": "Масштабний пошук у Базі знань",
   "scoped_knowledge_base_search_label_v2": "Обмежений пошук у довідковому центрі",
   "search_group_label": "Налаштування пошуку",
   "section_page_group_label": "Елементи сторінки розділу",

--- a/translations/vi.json
+++ b/translations/vi.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "Kết quả tìm kiếm được giới hạn trong chủ đề hiện tại của người dùng",
   "scoped_community_search_label": "Tìm kiếm theo phạm vi trong Cộng đồng",
   "scoped_knowledge_base_search_description": "Kết quả tìm kiếm được giới hạn trong nhóm hiện tại của người dùng",
-  "scoped_knowledge_base_search_label": "Tìm kiếm theo phạm vi trong Thư viện thông tin",
   "scoped_knowledge_base_search_label_v2": "Tìm kiếm theo phạm vi trong trung tâm trợ giúp",
   "search_group_label": "Cài đặt tìm kiếm",
   "section_page_group_label": "Các phần tử của trang mục",

--- a/translations/zh-cn.json
+++ b/translations/zh-cn.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "搜索结果限制在用户所在的主题内",
   "scoped_community_search_label": "社区中有范围限制的搜索",
   "scoped_knowledge_base_search_description": "搜索结果限制在用户所在的类别内",
-  "scoped_knowledge_base_search_label": "知识库中有范围限制的搜索",
   "scoped_knowledge_base_search_label_v2": "帮助中心范围内搜索",
   "search_group_label": "搜索设置",
   "section_page_group_label": "组别页面元素",

--- a/translations/zh-tw.json
+++ b/translations/zh-tw.json
@@ -59,7 +59,6 @@
   "scoped_community_search_description": "搜尋結果限於使用者所在主題",
   "scoped_community_search_label": "社區內的限定範圍搜尋",
   "scoped_knowledge_base_search_description": "搜尋結果限於使用者所在類別",
-  "scoped_knowledge_base_search_label": "知識庫內的限定範圍搜尋",
   "scoped_knowledge_base_search_label_v2": "客服中心的限定範圍搜尋",
   "search_group_label": "搜尋設定值",
   "section_page_group_label": "段落頁面元素",


### PR DESCRIPTION
## Summary

Full-branch audit of `sandbox` vs. upstream `zendesk/copenhagen_theme` (`master`) found several divergences from Zendesk theme conventions and this repo's own established patterns. This PR fixes all identified issues.

### Hardcoded URLs / dead code
- Removed dead commented-out org-specific URL and duplicate search markup in `home_page.hbs`
- Switched the signed-in CTA to Zendesk's default localized `{{link 'new_request'}}` text instead of a hardcoded "Report an issue" string

### i18n
- Used the existing `{{t 'my_requests'}}` stock key instead of hardcoding "My requests" in `service_page.hbs`
- Removed the obsolete `scoped_knowledge_base_search_label` key (marked `obsolete: 2025-06-12` in `translations.yml`; `manifest.json` only references `_v2`) from all 35 locale files, matching this repo's own precedent of not shipping obsolete keys in `translations/*.json`

### Inline CSS → SCSS
- Moved all 16 `@font-face` rules out of `document_head.hbs` `<style>` blocks into `styles/_fonts.scss`, using Zendesk's `$assets-<file>-<ext>` asset-variable convention (same mechanism used for settings-driven images like `$homepage_background_image`)

### SCSS token/dedup cleanup
- Replaced hardcoded hex literals that exactly duplicate existing `--svc-*` design tokens across `_svc-service-item.scss`, `_svc-header.scss`, and `_blocks.scss`
- Removed an exact duplicate ruleset in `_svc-header.scss`
- Consolidated duplicated skeleton shimmer keyframes/gradient (`_svc-home.scss` + `_svc-service-item.scss`) into one shared `%svc-skel-shimmer` placeholder in `_svc-tokens.scss`
- Fixed `_forms.scss` `.nesty-input` height/line-height mismatch (height bumped to 80px but line-height was left at 40px, top-aligning single-line text)
- Replaced the orphaned hardcoded `#0957BE` border color in `_header.scss` with `$brand_color`, matching the rest of that rule
- Verified (via grep against `templates/header.hbs`) that the unscoped `.submit-a-request:focus/:active` rule is **not** dead code — it's the only styling for the mobile-nav version of the button — and kept it, documenting why

### Inline `<script>` duplication → `src/` modules
- Extracted the copy-pasted personalized-greeting name-resolution logic from `service_page.hbs` and `service_list_page.hbs` into `src/svcGreeting.js` (`window.svcFetchFirstName`)
- Extracted the duplicated skeleton-reveal MutationObserver/timer controller into `src/svcReveal.js` (`window.initSvcRevealOnComplete`), used by both templates
- Extracted ~168 lines of catalog tooltip/description/search-removal/skeleton-tagging logic from `service_list_page.hbs` into `src/svcCatalogEnhancements.js`
- Moved the search-pill submit wiring out of `search_results.hbs` into `src/domFixups.js` as a third fix-up
- Replaced `innerHTML` string-concatenation with safe DOM construction for the catalog fallback link and training FAB icon

All new `window.*` calls from templates use the same defensive poll-retry pattern already established for `window.initSvcSearch`, since `script.js`'s load order relative to inline template scripts isn't guaranteed.

## Verification
- `yarn build` succeeds; `$assets-*` SCSS variables pass through unescaped exactly like other Zendesk asset vars
- `yarn test`: 592/592 passing
- `yarn eslint src`: 0 errors (pre-existing warnings only, unrelated to this change)
- Generated bundle noise (`assets/*-bundle.js`) reverted — confirmed non-deterministic across builds even with zero source changes

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>