### PR TITLE
fix/Service page search bar styling and dropdown z-index overlap

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,12 +14,6 @@ on:
       - '__mocks__/**'
       - 'jest.config.mjs'
       - 'jest.setup.js'
-      - 'tsconfig.json'
-      - 'rollup.config.mjs'
-      - 'zass.mjs'
-      - 'generate-import-map.mjs'
-      - 'package.json'
-      - 'yarn.lock'
       - 'src/**/*.test.ts'
       - 'src/**/*.test.tsx'
       - 'src/**/*.spec.ts'
@@ -38,12 +32,6 @@ on:
       - '__mocks__/**'
       - 'jest.config.mjs'
       - 'jest.setup.js'
-      - 'tsconfig.json'
-      - 'rollup.config.mjs'
-      - 'zass.mjs'
-      - 'generate-import-map.mjs'
-      - 'package.json'
-      - 'yarn.lock'
       - 'src/**/*.test.ts'
       - 'src/**/*.test.tsx'
       - 'src/**/*.spec.ts'
@@ -69,7 +57,16 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 24.x
+          node-version-file: '.nvmrc'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build theme assets
+        run: yarn build
 
       - name: Set theme version name
         run: |
@@ -86,7 +83,7 @@ jobs:
 
       - name: Zip theme files
         run: |
-          zip -r theme.zip . -x ".*"
+          zip -r theme.zip . -x ".*" -x "node_modules/*"
           mv theme.zip ./.github/workflows/scripts/
 
       - name: Run updateTheme.js

--- a/style.css
+++ b/style.css
@@ -7133,12 +7133,20 @@ body > pre, body > code, body > .template-name, body > .editor-label {
 .svc-searchrow .svc-hero-search {
   max-width: 560px;
   margin: 0 auto;
+  padding: 6px 6px 6px 20px;
   border: 1px solid #b9c9ef;
   box-shadow: 0 2px 6px rgba(0, 51, 153, 0.12);
 }
 
+.svc-searchrow .svc-hero-search input[type=search] {
+  font-size: 15px !important;
+  padding: 10px 12px !important;
+}
+
 .svc-searchrow .svc-hero-search-btn {
   background: #003b91;
+  width: 38px;
+  height: 38px;
 }
 
 .svc-mini-search {

--- a/style.css
+++ b/style.css
@@ -6821,7 +6821,6 @@ body {
 /* ---- SUBMIT BUTTON: overlap-aware hiding handled by JS ---- */
 .svc-custom-submit-wrap {
   position: relative;
-  z-index: 0;
 }
 
 /* ---- HELPER INFORMATION CARDS ---- */

--- a/style.css
+++ b/style.css
@@ -5530,6 +5530,7 @@ html body .header .search-wrapper {
   display: flex !important;
   align-items: center !important;
 }
+
 .svc-hero-input {
   flex: 1;
   min-width: 0;
@@ -6019,12 +6020,12 @@ a.svc-help-btn:hover,
 }
 
 /* Kill Garden wrapper focus border on catalog search */
-.service-catalog-main-content [data-garden-id*="forms"],
-.service-catalog-main-content [data-garden-id*="forms"] *,
-.service-catalog-main-content [data-garden-id*="mediaInput"],
-.service-catalog-main-content [data-garden-id*="mediaInput"] *,
-.service-catalog-main-content [class*="StyledMedia"],
-.service-catalog-main-content [class*="StyledMedia"]:focus-within {
+.service-catalog-main-content [data-garden-id*=forms],
+.service-catalog-main-content [data-garden-id*=forms] *,
+.service-catalog-main-content [data-garden-id*=mediaInput],
+.service-catalog-main-content [data-garden-id*=mediaInput] *,
+.service-catalog-main-content [class*=StyledMedia],
+.service-catalog-main-content [class*=StyledMedia]:focus-within {
   border-color: #dfe4ee !important;
   box-shadow: none !important;
   outline: none !important;
@@ -6807,8 +6808,6 @@ body {
 }
 
 /* ---- SUBMIT BUTTON: overlap-aware hiding handled by JS ---- */
-.svc-custom-submit-wrap {}
-
 /* Ensure form dropdowns render above the submit wrap */
 .svc-form-panel #service-catalog-item {
   position: relative;

--- a/style.css
+++ b/style.css
@@ -5503,11 +5503,18 @@ html body .header .search-wrapper {
   padding: 9px 9px 9px 26px;
   background: #fff;
   border-radius: 1000px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: none;
+  box-shadow: none;
+}
+
+.svc-hero-search > * {
+  border: none !important;
+  box-shadow: none !important;
 }
 
 .svc-hero-search-icon {
   display: inline-flex;
+  border: none;
   align-items: center;
   color: var(--svc-gray);
 }
@@ -5517,6 +5524,12 @@ html body .header .search-wrapper {
   height: 24px;
 }
 
+.svc-hero-search > *:not(.svc-hero-search-icon):not(.svc-hero-search-btn) {
+  flex: 1 1 auto !important;
+  min-width: 0 !important;
+  display: flex !important;
+  align-items: center !important;
+}
 .svc-hero-input {
   flex: 1;
   min-width: 0;
@@ -5524,12 +5537,30 @@ html body .header .search-wrapper {
   outline: none;
   background: transparent;
   font-family: var(--svc-font);
-  font-size: 18px;
+  font-size: 18px !important;
   color: var(--svc-ink);
   padding: 13px 16px;
 }
 
 .svc-hero-input::placeholder {
+  color: #9aa1ad;
+}
+
+.svc-hero-search input[type=search] {
+  flex: 1 1 auto !important;
+  width: 100% !important;
+  height: auto !important;
+  border: none !important;
+  outline: none !important;
+  background: transparent !important;
+  font-family: var(--svc-font);
+  font-size: 18px !important;
+  color: var(--svc-ink);
+  padding: 13px 16px !important;
+  box-shadow: none !important;
+}
+
+.svc-hero-search input[type=search]::placeholder {
   color: #9aa1ad;
 }
 
@@ -5780,7 +5811,7 @@ html body .header .search-wrapper {
 }
 
 /* Hide the catalog's own search box (hero search replaces it). */
-.service-catalog-main-content form[role=search],
+/*.service-catalog-main-content form[role=search],
 .service-catalog-main-content input[type=search],
 .service-catalog-main-content input[type=text],
 .service-catalog-main-content input:not([type]) {
@@ -5789,7 +5820,7 @@ html body .header .search-wrapper {
 
 .service-catalog-main-content .svc-native-search-hide {
   display: none !important;
-}
+}*/
 
 /* SERVICE ICONS — NEVER CLIP */
 .service-catalog-main-content figure,
@@ -5992,6 +6023,23 @@ a.svc-help-btn:hover,
 .service-catalog-main-content input[type=text],
 .service-catalog-main-content input[type=search] {
   border-radius: 16px !important;
+  padding: 2px 8px !important;
+  font-size: 14px !important;
+  caret-color: var(--svc-ink) !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+/* Kill Garden wrapper focus border on catalog search */
+.service-catalog-main-content [data-garden-id*="forms"],
+.service-catalog-main-content [data-garden-id*="forms"] *,
+.service-catalog-main-content [data-garden-id*="mediaInput"],
+.service-catalog-main-content [data-garden-id*="mediaInput"] *,
+.service-catalog-main-content [class*="StyledMedia"],
+.service-catalog-main-content [class*="StyledMedia"]:focus-within {
+  border-color: #dfe4ee !important;
+  box-shadow: none !important;
+  outline: none !important;
 }
 
 /* ---------- CATALOG SKELETON + FADE-IN ---------- */

--- a/style.css
+++ b/style.css
@@ -7130,6 +7130,17 @@ body > pre, body > code, body > .template-name, body > .editor-label {
   margin: 0 0 16px;
 }
 
+.svc-searchrow .svc-hero-search {
+  max-width: 560px;
+  margin: 0 auto;
+  border: 1px solid #b9c9ef;
+  box-shadow: 0 2px 6px rgba(0, 51, 153, 0.12);
+}
+
+.svc-searchrow .svc-hero-search-btn {
+  background: #003b91;
+}
+
 .svc-mini-search {
   position: relative;
   display: flex;

--- a/style.css
+++ b/style.css
@@ -5810,18 +5810,6 @@ html body .header .search-wrapper {
   font-weight: 400 !important;
 }
 
-/* Hide the catalog's own search box (hero search replaces it). */
-/*.service-catalog-main-content form[role=search],
-.service-catalog-main-content input[type=search],
-.service-catalog-main-content input[type=text],
-.service-catalog-main-content input:not([type]) {
-  display: none !important;
-}
-
-.service-catalog-main-content .svc-native-search-hide {
-  display: none !important;
-}*/
-
 /* SERVICE ICONS — NEVER CLIP */
 .service-catalog-main-content figure,
 .service-catalog-main-content [data-garden-id="avatars.avatar"],

--- a/style.css
+++ b/style.css
@@ -6819,8 +6819,12 @@ body {
 }
 
 /* ---- SUBMIT BUTTON: overlap-aware hiding handled by JS ---- */
-.svc-custom-submit-wrap {
+.svc-custom-submit-wrap {}
+
+/* Ensure form dropdowns render above the submit wrap */
+.svc-form-panel #service-catalog-item {
   position: relative;
+  z-index: 1;
 }
 
 /* ---- HELPER INFORMATION CARDS ---- */

--- a/styles/_svc-home.scss
+++ b/styles/_svc-home.scss
@@ -99,10 +99,21 @@
   padding: 9px 9px 9px 26px;
   background: #fff;
   border-radius: 1000px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: none;
+  box-shadow: none;
 }
-.svc-hero-search-icon { display: inline-flex; align-items: center; color: var(--svc-gray); }
+.svc-hero-search > * {
+  border: none !important;
+  box-shadow: none !important;
+}
+.svc-hero-search-icon { display: inline-flex; border: none; align-items: center; color: var(--svc-gray); }
 .svc-hero-search-icon svg { width: 24px; height: 24px; }
+.svc-hero-search > *:not(.svc-hero-search-icon):not(.svc-hero-search-btn) {
+  flex: 1 1 auto !important;
+  min-width: 0 !important;
+  display: flex !important;
+  align-items: center !important;
+}
 .svc-hero-input {
   flex: 1;
   min-width: 0;
@@ -110,11 +121,25 @@
   outline: none;
   background: transparent;
   font-family: var(--svc-font);
-  font-size: 18px;
+  font-size: 18px !important;
   color: var(--svc-ink);
   padding: 13px 16px;
 }
 .svc-hero-input::placeholder { color: #9aa1ad; }
+.svc-hero-search input[type="search"] {
+  flex: 1 1 auto !important;
+  width: 100% !important;
+  height: auto !important;
+  border: none !important;
+  outline: none !important;
+  background: transparent !important;
+  font-family: var(--svc-font);
+  font-size: 18px !important;
+  color: var(--svc-ink);
+  padding: 13px 16px !important;
+  box-shadow: none !important;
+}
+.svc-hero-search input[type="search"]::placeholder { color: #9aa1ad; }
 .svc-hero-search-btn {
   display: inline-flex;
   align-items: center;
@@ -245,13 +270,6 @@
 .service-catalog-main-content a[href*="/services/"] *,
 .service-catalog-main-content [class*="card"] *,
 .service-catalog-main-content [class*="Card"] * { font-weight: 400 !important; }
-
-/* Hide the catalog's own search box (hero search replaces it). */
-.service-catalog-main-content form[role="search"],
-.service-catalog-main-content input[type="search"],
-.service-catalog-main-content input[type="text"],
-.service-catalog-main-content input:not([type]) { display: none !important; }
-.service-catalog-main-content .svc-native-search-hide { display: none !important; }
 
 /* SERVICE ICONS — NEVER CLIP */
 .service-catalog-main-content figure,
@@ -407,7 +425,26 @@ a.svc-help-btn:hover,
 
 /* Search input rounding (defensive) */
 .service-catalog-main-content input[type="text"],
-.service-catalog-main-content input[type="search"] { border-radius: 16px !important; }
+.service-catalog-main-content input[type="search"] {
+  border-radius: 16px !important;
+  padding: 2px 8px !important;
+  font-size: 14px !important;
+  caret-color: var(--svc-ink) !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+/* Kill Garden wrapper focus border on catalog search */
+.service-catalog-main-content [data-garden-id*="forms"],
+.service-catalog-main-content [data-garden-id*="forms"] *,
+.service-catalog-main-content [data-garden-id*="mediaInput"],
+.service-catalog-main-content [data-garden-id*="mediaInput"] *,
+.service-catalog-main-content [class*="StyledMedia"],
+.service-catalog-main-content [class*="StyledMedia"]:focus-within {
+  border-color: #dfe4ee !important;
+  box-shadow: none !important;
+  outline: none !important;
+}
 
 /* ---------- CATALOG SKELETON + FADE-IN ---------- */
 .svc-catalog-stage { position: relative; min-height: 460px; }

--- a/styles/_svc-service-item.scss
+++ b/styles/_svc-service-item.scss
@@ -232,9 +232,10 @@ body { background: #ffffff; }
 .svc-custom-submit-note { margin: 0; font-size: 12px; color: #6b7280; }
 
 /* ---- SUBMIT BUTTON: overlap-aware hiding handled by JS ---- */
-.svc-custom-submit-wrap {
+/* Ensure form dropdowns render above the submit wrap */
+.svc-form-panel #service-catalog-item {
   position: relative;
-  z-index: 0;
+  z-index: 1;
 }
 
 /* ---- HELPER INFORMATION CARDS ---- */
@@ -350,6 +351,26 @@ body > pre, body > code, body > .template-name, body > .editor-label { display: 
 
 /* ---- COMPACT SEARCH ROW ---- */
 .svc-searchrow { margin: 0 0 16px; }
+
+.svc-searchrow .svc-hero-search {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 6px 6px 6px 20px;
+  border: 1px solid #b9c9ef;
+  box-shadow: 0 2px 6px rgba(0, 51, 153, 0.12);
+}
+
+.svc-searchrow .svc-hero-search input[type="search"] {
+  font-size: 15px !important;
+  padding: 10px 12px !important;
+}
+
+.svc-searchrow .svc-hero-search-btn {
+  background: #003b91;
+  width: 38px;
+  height: 38px;
+}
+
 .svc-mini-search {
   position: relative;
   display: flex;

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -1,289 +1,134 @@
-{{!--
-  Home page (service_list_page) — hero + combined live search + service catalog.
-  Styling: styles/_svc-home.scss (design tokens in _svc-tokens.scss). Do NOT add
-  <style> blocks or style="" attributes here — edit the SCSS partials instead.
-
-  The hero is static, fully-styled markup and renders immediately (no
-  hide-by-default guard). Only the async service-catalog uses a skeleton
-  placeholder and fades in once staged (.svc-cat-ready). The page-specific JS
-  below needs server-rendered {{json}} data, so it stays inline on this page.
---}}
-
+<!-- Customized 06.07.2026 by joel.peterson@arpa-h.gov -->
 <h1 class="visibility-hidden">{{ help_center.name }}</h1>
-<script>
-  /* Tag <html>/<body> as the home page so the global header can restyle
-     itself over the hero (Zendesk adds no built-in home-page class). */
-  (function () {
-    var add = function () {
-      document.documentElement.classList.add('svc-home');
-      if (document.body) document.body.classList.add('svc-home');
-    };
-    add();
-    document.addEventListener('DOMContentLoaded', add);
-  })();
-</script>
 
-<!-- ===== HERO (greeting + search) ===== -->
-<section id="hero-content" class="section hero svc-hero">
-  <div class="hero-inner svc-hero-inner">
-    {{#if signed_in}}
-    <div class="svc-hero-greeting">
-      <h2 class="svc-hero-title"><span id="svc-list-greeting">&nbsp;</span><span id="svc-list-greeting-name" class="svc-greeting-name"></span></h2>
-      <p class="svc-hero-subtitle" id="svc-list-subtitle">What do you need help with today?</p>
-
-      {{!-- Native Zendesk instant search (articles), skinned into the hero
-            pill. Real-time suggestions and the results page are rendered by
-            the platform — there is no custom fetch/scoring layer. The left
-            icon is decorative; the pink button submits the native form (wired
-            in the script below). Styling lives in styles/_svc-home.scss. --}}
-      <h2 class="visibility-hidden">{{ t 'search' }}</h2>
-      <div class="svc-hero-search" id="svc-hero-search">
-        <span class="svc-hero-search-icon" aria-hidden="true">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-          </svg>
-        </span>
-        {{search submit=false instant=settings.instant_search class='search search-full'}}
-        <button type="button" class="svc-hero-search-btn" id="svc-hero-search-btn" aria-label="{{t 'search'}}">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-          </svg>
-        </button>
-      </div>
-
-      <div class="svc-hero-chips" id="svc-hero-chips">
-        <span class="svc-hero-chips-label">Popular:</span>
-        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=PIV%20certificate%20renewal">PIV Cert Renewal</a>
-        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=lost%20stolen%20device">Lost/Stolen Device</a>
-        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=lost%20stolen%20PIV%20card">Lost/Stolen PIV Card</a>
-        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=external%20sharepoint">SharePoint</a>
-        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=shared%20mailbox%20distribution%20list">Shared Mailboxes/Distribution Lists</a>
-      </div>
+<section id="main-content" class="section hero">
+  <div class="hero-inner">
+    {{!-- <h2 class="visibility-hidden">{{ t 'search' }}</h2>
+    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
+      <circle cx="4.5" cy="4.5" r="4" fill="none" stroke="currentColor"/>
+      <path stroke="currentColor" stroke-linecap="round" d="M11 11L7.5 7.5"/>
+    </svg>
+    {{search submit=false instant=settings.instant_search class='search search-full'}}
+    --}}
+   {{#if signed_in}}
+    <div class="centered-buttons">
+		  <span class="item">{{#link 'new_request' class='submit-a-request'}}Report an issue{{/link}}</span>
+      <!-- <span class="item submit-a-request"><a href="https://arpah1746463021.zendesk.com/hc/en-us/services">Services</a></span> -->
     </div>
-    {{/if}}
-  </div>
+   {{/if}}     
 </section>
-
-<script>
-  /* Time-based greeting set synchronously, before first paint. */
-  (function () {
-    var el = document.getElementById('svc-list-greeting');
-    if (!el) return;
-    var h = new Date().getHours();
-    el.textContent = h < 12 ? 'Good morning' : h < 17 ? 'Good afternoon' : 'Good evening';
-  })();
-</script>
 
 {{#unless signed_in}}
 <div class="container banner-container">
   {{#if settings.display_alert_banner}}
     <div class="nav-wrapper-desktop alert-banner">
-      <div class="bell-notice-text"><div class="inner-site-notice"><p>{{settings.alert_banner_text}}</p></div></div>
+      <div class="bell-notice-text">
+        <div class="inner-site-notice">
+          <p>
+            {{settings.alert_banner_text}}
+          </p>
+        </div>
+      </div>
     </div>
     <div class="nav-wrapper-mobile alert-wrapper-mobile">
-      <div class="alert-banner-text"><div class="inner-site-notice"><p>{{settings.alert_banner_text}}</p></div></div>
+      <div class="alert-banner-text">
+        <div class="inner-site-notice">
+          <p>
+            {{settings.alert_banner_text}}
+          </p>
+        </div>
+      </div>
+
     </div>
   {{/if}}
 </div>
 {{/unless}}
+<div class="container">
+  <section class="section knowledge-base">
+    <h2 class="visibility-hidden">{{ t 'categories' }}</h2>
+    <section class="categories blocks">
+      <ul class="blocks-list">
+        {{#each categories}}
+          {{#if ../has_multiple_categories}}
+            {{!-- <li class="blocks-item"> --}}
+            <li class="blocks-item blocks-item-category-{{id}}">
+              <a href='{{url}}' class="blocks-item-link">
+                   <!-- Category image -->
+                <span class="blocks-item-img-wrapper">
+                  {{! Human Resources }}
+                  {{#is id 37066828975515}}<img class="blocks-item-img" alt="People at table icon representing Human Resources." src="{{asset 'ARPA-H-icons-humanresouces-01-rgb-full-color.svg'}}" />{{/is}} 
+                  {{! Service Desk }}
+                  {{#is id 19382804915227}}<img class="blocks-item-img" alt="Magnifying glass icon representing help desk." src="{{asset 'ARPA-H-icons-magnifying-glass-rgb-full-color.svg'}}" />{{/is}}
+                  {{! Asset Management }}
+                  {{#is id 30126071388315}}<img class="blocks-item-img" alt="Icon representing asset management." src="{{asset 'ARPA-H-icons-community-rgb-full-color.svg'}}" />{{/is}}
+                  {{! Self Service }}
+                  {{#is id 19382827542427}}<img class="blocks-item-img" alt="Organization chart icon representing user support." src="{{asset 'ARPA-H-icons-org-chart-02-rgb-full-color.svg'}}" />{{/is}}
+                  {{! External User Support }}
+                  {{#is id 37066784640923}}<img class="blocks-item-img" alt="Shaking hands icon represening external user support." src="{{asset 'ARPA-H-icons-handshake-01-rgb-full-color.svg'}}" />{{/is}}
+                </span>
+                <!-- End category image -->
+                <span class="blocks-item-title">{{name}}</span>
+                <span class="blocks-item-description">{{excerpt description}}</span>
+              </a>
+            </li>
+          {{else}}
+            {{#each sections}}
+              <li class="blocks-item">
+                <a href='{{url}}' class="blocks-item-link">
+                  <span class="blocks-item-img-wrapper">
+                    {{! Self Service FAQs}}
+                    {{#is id 19383045462299}}<img class="blocks-item-img" alt="Magnifying glass icon representing FAQs." src="{{asset 'ARPA-H-icons-magnifying-glass-rgb-full-color.svg'}}" />{{/is}}
+                  </span>
+                  <span class="blocks-item-title">
+                    {{name}}
+                  </span>
+                  <span class="blocks-item-description">{{excerpt description}}</span>
+                </a>
+              </li>
+            {{/each}}
+          {{/if}}
+        {{/each}}
+      </ul>
+      {{pagination}}
+    </section>
 
-<!-- ===== SERVICE CATALOG (wide floating card) ===== -->
-{{#if signed_in}}
-<div class="svc-cardwrap">
-  <div id="svc-home-content">
-    <div class="svc-list-shell">
-      <div class="svc-catalog-stage">
-        <div id="service-catalog-main-content" class="service-catalog-main-content"></div>
-        <!-- Skeleton placeholder for the catalog. -->
-        <div id="svc-catalog-skeleton" class="svc-cat-skeleton" aria-hidden="true">
-          <div class="svc-cat-skel-side">
-            <div class="svc-cat-skel-row svc-cat-skel-row-active"></div>
-            <div class="svc-cat-skel-row"></div>
-            <div class="svc-cat-skel-row"></div>
-            <div class="svc-cat-skel-row"></div>
-            <div class="svc-cat-skel-row"></div>
-            <div class="svc-cat-skel-row"></div>
-            <div class="svc-cat-skel-row"></div>
-          </div>
-          <div class="svc-cat-skel-main">
-            <div class="svc-cat-skel-heading"></div>
-            <div class="svc-cat-skel-subtext"></div>
-            <div class="svc-cat-skel-grid">
-              <div class="svc-cat-skel-card"></div>
-              <div class="svc-cat-skel-card"></div>
-              <div class="svc-cat-skel-card"></div>
-              <div class="svc-cat-skel-card"></div>
-              <div class="svc-cat-skel-card"></div>
-              <div class="svc-cat-skel-card"></div>
-            </div>
-          </div>
-        </div>
-      </div>
-            <!-- Static "Can't find it" banner. -->
-      <div class="svc-help-banner">
-        <div class="svc-help-banner-text">
-          <span class="svc-help-banner-title">Still can&rsquo;t find what you need?</span>
-          <span class="svc-help-banner-sub">Submit a general request.</span>
-        </div>
-        <a class="svc-help-btn" href="/hc/{{help_center.base_locale}}/services/{{settings.other_request_service_id}}">
-          General request
-        </a>
-      </div>
-    </div>
-  </div>
+    {{#if promoted_articles}}
+      <section class="articles">
+        <h2>{{t 'promoted_articles'}}</h2>
+        <ul class="article-list promoted-articles">
+          {{#each promoted_articles}}
+            <li class="promoted-articles-item">
+                <a href="{{url}}">
+                  {{title}}
+
+                  {{#if internal}}
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
+                      <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
+                      <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
+                    </svg>
+                  {{/if}}
+                </a>
+            </li>
+          {{/each}}
+        </ul>
+      </section>
+    {{/if}}
+  </section>
+{{!--
+  {{#if help_center.community_enabled}}
+    <section class="section home-section community">
+      <h2>{{t 'community'}}</h2>
+      {{#link 'community' class='community-link'}}
+        {{t 'join_conversation'}}
+      {{/link}}
+
+      <div class="community-image"></div>
+    </section>
+  {{/if}}
+--}}
+  <section class="section home-section activity">
+    {{#if settings.show_recent_activity}}
+      {{recent_activity}}
+    {{/if}}
+  </section>
 </div>
-{{/if}}
-
-{{#if signed_in}}
-<!-- Render the Zendesk service catalog into our card -->
-<script type="module">
-  try {
-    const { renderServiceCatalogPage } = await import("service-catalog");
-    const main = document.getElementById("service-catalog-main-content");
-    if (main) {
-      renderServiceCatalogPage(
-        main,
-        {{json settings}},
-        {{json help_center.base_locale}},
-        {{json (page_path 'help_center')}}
-      );
-    }
-  } catch (e) {
-    console.warn("Service catalog module unavailable:", e);
-    const main = document.getElementById("service-catalog-main-content");
-    if (main) {
-      const hcBase = (location.pathname.match(/^\/hc\/[^/]+/) || ["/hc/en-us"])[0];
-      // Built via DOM APIs (not innerHTML string concatenation) so hcBase —
-      // derived from location.pathname — can never be interpreted as markup.
-      const fallback = document.createElement("p");
-      fallback.className = "svc-catalog-fallback";
-      fallback.append("View the full ");
-      const link = document.createElement("a");
-      link.href = `${hcBase}/services`;
-      link.textContent = "Service Catalog";
-      fallback.append(link, ".");
-      main.replaceChildren(fallback);
-    }
-  }
-</script>
-
-<!-- Personalized time-based greeting in the hero. Name-resolution fetch is
-     shared with service_page.hbs via src/svcGreeting.js
-     (window.svcFetchFirstName); the fade-in timing below is page-specific. -->
-<script>
-  (function () {
-    const nameEl = document.getElementById('svc-list-greeting-name');
-    if (!nameEl) return;
-
-    function setGreeting(first) {
-      if (!first) return;
-      const text = `, ${first}`;
-      if ((nameEl.textContent || '') === text && nameEl.classList.contains('svc-name-in')) return;
-      nameEl.textContent = text;
-      requestAnimationFrame(() => nameEl.classList.add('svc-name-in'));
-    }
-
-    // script.js (which defines window.svcFetchFirstName) is a classic script
-    // whose load order relative to this inline block isn't guaranteed, so
-    // poll briefly instead of assuming it has already run.
-    function tryFetch() {
-      if (typeof window.svcFetchFirstName === 'function') {
-        window.svcFetchFirstName(setGreeting);
-        return true;
-      }
-      return false;
-    }
-    if (!tryFetch()) {
-      let attempts = 0;
-      const iv = setInterval(() => {
-        attempts++;
-        if (tryFetch() || attempts > 100) clearInterval(iv);
-      }, 20);
-    }
-  })();
-</script>
-
-<!-- Native instant-search wiring: submit the native {{search}} form when the
-     pink button is clicked, and keep the ARPA-H placeholder text. The
-     real-time article suggestions and the results page are provided by
-     Zendesk's platform — there is no custom fetch/scoring layer. -->
-<script>
-  (function () {
-    var wrap = document.getElementById('svc-hero-search');
-    if (!wrap) return;
-    var form  = wrap.querySelector('form[role="search"]');
-    var input = wrap.querySelector('input[type="search"]');
-    var btn   = document.getElementById('svc-hero-search-btn');
-
-    if (input) input.setAttribute('placeholder', 'Search by service or keyword (e.g., Software, Device, SharePoint)…');
-
-    if (btn && form) {
-      btn.addEventListener('click', function () {
-        if (input && !input.value.trim()) { input.focus(); return; }
-        if (typeof form.requestSubmit === 'function') form.requestSubmit();
-        else form.submit();
-      });
-    }
-  })();
-</script>
-
-<!-- Catalog enhancements (tooltips, category text, search removal) and
-     category-swap skeleton hiding now live in src/svcCatalogEnhancements.js
-     (bundled into script.js) since neither depends on server-rendered
-     Curlybars data. Do not re-add them inline. -->
-
-<!-- Catalog reveal controller. The hero is static, fully-styled markup and is
-     visible immediately (no hide-by-default guard); only the async service
-     catalog is gated. This swaps the skeleton for the real catalog
-     (.svc-cat-ready) once it is complete. (.svc-ready is now a harmless no-op,
-     kept only so existing callers don't need touching.)
-     Shared reveal-on-complete controller lives in src/svcReveal.js
-     (window.initSvcRevealOnComplete), consistent with service_page.hbs's
-     form-skeleton reveal. SAFETY: 6s JS hard cap + 6.5s CSS failsafe +
-     instant reveal on bfcache. -->
-<script>
-  (function () {
-    var root = document.documentElement;
-
-    // Reveal the hero immediately once the page is interactive — the hero is
-    // our own fully-styled markup, so there's no reason to hold it for the
-    // catalog. Holding only the catalog behind its skeleton avoids the flash
-    // while keeping the greeting snappy.
-    function revealHero() { root.classList.add('svc-ready'); }
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', revealHero);
-    } else {
-      revealHero();
-    }
-    window.addEventListener('pageshow', function (e) { if (e.persisted) revealHero(); });
-
-    var config = {
-      targetId: 'service-catalog-main-content',
-      skeletonId: 'svc-catalog-skeleton',
-      skeletonHideClass: 'svc-cat-skel-hide',
-      readyClasses: ['svc-cat-ready'],
-      // "Complete" = the catalog has real service links rendered.
-      isComplete: function (main) {
-        return !!main.querySelector('a[href*="/services/"]');
-      }
-    };
-    // script.js (which defines window.initSvcRevealOnComplete) is a classic
-    // script whose load order relative to this inline block isn't
-    // guaranteed, so poll briefly instead of assuming it has already run.
-    function tryInit() {
-      if (typeof window.initSvcRevealOnComplete === 'function') {
-        window.initSvcRevealOnComplete(config);
-        return true;
-      }
-      return false;
-    }
-    if (!tryInit()) {
-      var attempts = 0;
-      var iv = setInterval(function () {
-        attempts++;
-        if (tryInit() || attempts > 100) clearInterval(iv);
-      }, 20);
-    }
-  })();
-</script>
-{{/if}}

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -1,126 +1,289 @@
-<!-- Customized 06.07.2026 by joel.peterson@arpa-h.gov -->
-<h1 class="visibility-hidden">{{ help_center.name }}</h1>
+{{!--
+  Home page (service_list_page) — hero + combined live search + service catalog.
+  Styling: styles/_svc-home.scss (design tokens in _svc-tokens.scss). Do NOT add
+  <style> blocks or style="" attributes here — edit the SCSS partials instead.
 
-<section id="main-content" class="section hero">
-  <div class="hero-inner">
-   {{#if signed_in}}
-    <div class="centered-buttons">
-      <span class="item">{{link 'new_request' class='submit-a-request'}}</span>
+  The hero is static, fully-styled markup and renders immediately (no
+  hide-by-default guard). Only the async service-catalog uses a skeleton
+  placeholder and fades in once staged (.svc-cat-ready). The page-specific JS
+  below needs server-rendered {{json}} data, so it stays inline on this page.
+--}}
+
+<h1 class="visibility-hidden">{{ help_center.name }}</h1>
+<script>
+  /* Tag <html>/<body> as the home page so the global header can restyle
+     itself over the hero (Zendesk adds no built-in home-page class). */
+  (function () {
+    var add = function () {
+      document.documentElement.classList.add('svc-home');
+      if (document.body) document.body.classList.add('svc-home');
+    };
+    add();
+    document.addEventListener('DOMContentLoaded', add);
+  })();
+</script>
+
+<!-- ===== HERO (greeting + search) ===== -->
+<section id="hero-content" class="section hero svc-hero">
+  <div class="hero-inner svc-hero-inner">
+    {{#if signed_in}}
+    <div class="svc-hero-greeting">
+      <h2 class="svc-hero-title"><span id="svc-list-greeting">&nbsp;</span><span id="svc-list-greeting-name" class="svc-greeting-name"></span></h2>
+      <p class="svc-hero-subtitle" id="svc-list-subtitle">What do you need help with today?</p>
+
+      {{!-- Native Zendesk instant search (articles), skinned into the hero
+            pill. Real-time suggestions and the results page are rendered by
+            the platform — there is no custom fetch/scoring layer. The left
+            icon is decorative; the pink button submits the native form (wired
+            in the script below). Styling lives in styles/_svc-home.scss. --}}
+      <h2 class="visibility-hidden">{{ t 'search' }}</h2>
+      <div class="svc-hero-search" id="svc-hero-search">
+        <span class="svc-hero-search-icon" aria-hidden="true">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+        </span>
+        {{search submit=false instant=settings.instant_search class='search search-full'}}
+        <button type="button" class="svc-hero-search-btn" id="svc-hero-search-btn" aria-label="{{t 'search'}}">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+        </button>
+      </div>
+
+      <div class="svc-hero-chips" id="svc-hero-chips">
+        <span class="svc-hero-chips-label">Popular:</span>
+        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=PIV%20certificate%20renewal">PIV Cert Renewal</a>
+        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=lost%20stolen%20device">Lost/Stolen Device</a>
+        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=lost%20stolen%20PIV%20card">Lost/Stolen PIV Card</a>
+        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=external%20sharepoint">SharePoint</a>
+        <a class="svc-hero-chip" href="/hc/{{help_center.base_locale}}/search?query=shared%20mailbox%20distribution%20list">Shared Mailboxes/Distribution Lists</a>
+      </div>
     </div>
-   {{/if}}
+    {{/if}}
+  </div>
 </section>
+
+<script>
+  /* Time-based greeting set synchronously, before first paint. */
+  (function () {
+    var el = document.getElementById('svc-list-greeting');
+    if (!el) return;
+    var h = new Date().getHours();
+    el.textContent = h < 12 ? 'Good morning' : h < 17 ? 'Good afternoon' : 'Good evening';
+  })();
+</script>
 
 {{#unless signed_in}}
 <div class="container banner-container">
   {{#if settings.display_alert_banner}}
     <div class="nav-wrapper-desktop alert-banner">
-      <div class="bell-notice-text">
-        <div class="inner-site-notice">
-          <p>
-            {{settings.alert_banner_text}}
-          </p>
-        </div>
-      </div>
+      <div class="bell-notice-text"><div class="inner-site-notice"><p>{{settings.alert_banner_text}}</p></div></div>
     </div>
     <div class="nav-wrapper-mobile alert-wrapper-mobile">
-      <div class="alert-banner-text">
-        <div class="inner-site-notice">
-          <p>
-            {{settings.alert_banner_text}}
-          </p>
-        </div>
-      </div>
-
+      <div class="alert-banner-text"><div class="inner-site-notice"><p>{{settings.alert_banner_text}}</p></div></div>
     </div>
   {{/if}}
 </div>
 {{/unless}}
-<div class="container">
-  <section class="section knowledge-base">
-    <h2 class="visibility-hidden">{{ t 'categories' }}</h2>
-    <section class="categories blocks">
-      <ul class="blocks-list">
-        {{#each categories}}
-          {{#if ../has_multiple_categories}}
-            {{!-- <li class="blocks-item"> --}}
-            <li class="blocks-item blocks-item-category-{{id}}">
-              <a href='{{url}}' class="blocks-item-link">
-                   <!-- Category image -->
-                <span class="blocks-item-img-wrapper">
-                  {{! Human Resources }}
-                  {{#is id 37066828975515}}<img class="blocks-item-img" alt="People at table icon representing Human Resources." src="{{asset 'ARPA-H-icons-humanresouces-01-rgb-full-color.svg'}}" />{{/is}} 
-                  {{! Service Desk }}
-                  {{#is id 19382804915227}}<img class="blocks-item-img" alt="Magnifying glass icon representing help desk." src="{{asset 'ARPA-H-icons-magnifying-glass-rgb-full-color.svg'}}" />{{/is}}
-                  {{! Asset Management }}
-                  {{#is id 30126071388315}}<img class="blocks-item-img" alt="Icon representing asset management." src="{{asset 'ARPA-H-icons-community-rgb-full-color.svg'}}" />{{/is}}
-                  {{! Self Service }}
-                  {{#is id 19382827542427}}<img class="blocks-item-img" alt="Organization chart icon representing user support." src="{{asset 'ARPA-H-icons-org-chart-02-rgb-full-color.svg'}}" />{{/is}}
-                  {{! External User Support }}
-                  {{#is id 37066784640923}}<img class="blocks-item-img" alt="Shaking hands icon represening external user support." src="{{asset 'ARPA-H-icons-handshake-01-rgb-full-color.svg'}}" />{{/is}}
-                </span>
-                <!-- End category image -->
-                <span class="blocks-item-title">{{name}}</span>
-                <span class="blocks-item-description">{{excerpt description}}</span>
-              </a>
-            </li>
-          {{else}}
-            {{#each sections}}
-              <li class="blocks-item">
-                <a href='{{url}}' class="blocks-item-link">
-                  <span class="blocks-item-img-wrapper">
-                    {{! Self Service FAQs}}
-                    {{#is id 19383045462299}}<img class="blocks-item-img" alt="Magnifying glass icon representing FAQs." src="{{asset 'ARPA-H-icons-magnifying-glass-rgb-full-color.svg'}}" />{{/is}}
-                  </span>
-                  <span class="blocks-item-title">
-                    {{name}}
-                  </span>
-                  <span class="blocks-item-description">{{excerpt description}}</span>
-                </a>
-              </li>
-            {{/each}}
-          {{/if}}
-        {{/each}}
-      </ul>
-      {{pagination}}
-    </section>
 
-    {{#if promoted_articles}}
-      <section class="articles">
-        <h2>{{t 'promoted_articles'}}</h2>
-        <ul class="article-list promoted-articles">
-          {{#each promoted_articles}}
-            <li class="promoted-articles-item">
-                <a href="{{url}}">
-                  {{title}}
-
-                  {{#if internal}}
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-lock" title="{{t 'internal'}}">
-                      <rect width="12" height="9" x="2" y="7" fill="currentColor" rx="1" ry="1"/>
-                      <path fill="none" stroke="currentColor" d="M4.5 7.5V4a3.5 3.5 0 017 0v3.5"/>
-                    </svg>
-                  {{/if}}
-                </a>
-            </li>
-          {{/each}}
-        </ul>
-      </section>
-    {{/if}}
-  </section>
-{{!--
-  {{#if help_center.community_enabled}}
-    <section class="section home-section community">
-      <h2>{{t 'community'}}</h2>
-      {{#link 'community' class='community-link'}}
-        {{t 'join_conversation'}}
-      {{/link}}
-
-      <div class="community-image"></div>
-    </section>
-  {{/if}}
---}}
-  <section class="section home-section activity">
-    {{#if settings.show_recent_activity}}
-      {{recent_activity}}
-    {{/if}}
-  </section>
+<!-- ===== SERVICE CATALOG (wide floating card) ===== -->
+{{#if signed_in}}
+<div class="svc-cardwrap">
+  <div id="svc-home-content">
+    <div class="svc-list-shell">
+      <div class="svc-catalog-stage">
+        <div id="service-catalog-main-content" class="service-catalog-main-content"></div>
+        <!-- Skeleton placeholder for the catalog. -->
+        <div id="svc-catalog-skeleton" class="svc-cat-skeleton" aria-hidden="true">
+          <div class="svc-cat-skel-side">
+            <div class="svc-cat-skel-row svc-cat-skel-row-active"></div>
+            <div class="svc-cat-skel-row"></div>
+            <div class="svc-cat-skel-row"></div>
+            <div class="svc-cat-skel-row"></div>
+            <div class="svc-cat-skel-row"></div>
+            <div class="svc-cat-skel-row"></div>
+            <div class="svc-cat-skel-row"></div>
+          </div>
+          <div class="svc-cat-skel-main">
+            <div class="svc-cat-skel-heading"></div>
+            <div class="svc-cat-skel-subtext"></div>
+            <div class="svc-cat-skel-grid">
+              <div class="svc-cat-skel-card"></div>
+              <div class="svc-cat-skel-card"></div>
+              <div class="svc-cat-skel-card"></div>
+              <div class="svc-cat-skel-card"></div>
+              <div class="svc-cat-skel-card"></div>
+              <div class="svc-cat-skel-card"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+            <!-- Static "Can't find it" banner. -->
+      <div class="svc-help-banner">
+        <div class="svc-help-banner-text">
+          <span class="svc-help-banner-title">Still can&rsquo;t find what you need?</span>
+          <span class="svc-help-banner-sub">Submit a general request.</span>
+        </div>
+        <a class="svc-help-btn" href="/hc/{{help_center.base_locale}}/services/{{settings.other_request_service_id}}">
+          General request
+        </a>
+      </div>
+    </div>
+  </div>
 </div>
+{{/if}}
+
+{{#if signed_in}}
+<!-- Render the Zendesk service catalog into our card -->
+<script type="module">
+  try {
+    const { renderServiceCatalogPage } = await import("service-catalog");
+    const main = document.getElementById("service-catalog-main-content");
+    if (main) {
+      renderServiceCatalogPage(
+        main,
+        {{json settings}},
+        {{json help_center.base_locale}},
+        {{json (page_path 'help_center')}}
+      );
+    }
+  } catch (e) {
+    console.warn("Service catalog module unavailable:", e);
+    const main = document.getElementById("service-catalog-main-content");
+    if (main) {
+      const hcBase = (location.pathname.match(/^\/hc\/[^/]+/) || ["/hc/en-us"])[0];
+      // Built via DOM APIs (not innerHTML string concatenation) so hcBase —
+      // derived from location.pathname — can never be interpreted as markup.
+      const fallback = document.createElement("p");
+      fallback.className = "svc-catalog-fallback";
+      fallback.append("View the full ");
+      const link = document.createElement("a");
+      link.href = `${hcBase}/services`;
+      link.textContent = "Service Catalog";
+      fallback.append(link, ".");
+      main.replaceChildren(fallback);
+    }
+  }
+</script>
+
+<!-- Personalized time-based greeting in the hero. Name-resolution fetch is
+     shared with service_page.hbs via src/svcGreeting.js
+     (window.svcFetchFirstName); the fade-in timing below is page-specific. -->
+<script>
+  (function () {
+    const nameEl = document.getElementById('svc-list-greeting-name');
+    if (!nameEl) return;
+
+    function setGreeting(first) {
+      if (!first) return;
+      const text = `, ${first}`;
+      if ((nameEl.textContent || '') === text && nameEl.classList.contains('svc-name-in')) return;
+      nameEl.textContent = text;
+      requestAnimationFrame(() => nameEl.classList.add('svc-name-in'));
+    }
+
+    // script.js (which defines window.svcFetchFirstName) is a classic script
+    // whose load order relative to this inline block isn't guaranteed, so
+    // poll briefly instead of assuming it has already run.
+    function tryFetch() {
+      if (typeof window.svcFetchFirstName === 'function') {
+        window.svcFetchFirstName(setGreeting);
+        return true;
+      }
+      return false;
+    }
+    if (!tryFetch()) {
+      let attempts = 0;
+      const iv = setInterval(() => {
+        attempts++;
+        if (tryFetch() || attempts > 100) clearInterval(iv);
+      }, 20);
+    }
+  })();
+</script>
+
+<!-- Native instant-search wiring: submit the native {{search}} form when the
+     pink button is clicked, and keep the ARPA-H placeholder text. The
+     real-time article suggestions and the results page are provided by
+     Zendesk's platform — there is no custom fetch/scoring layer. -->
+<script>
+  (function () {
+    var wrap = document.getElementById('svc-hero-search');
+    if (!wrap) return;
+    var form  = wrap.querySelector('form[role="search"]');
+    var input = wrap.querySelector('input[type="search"]');
+    var btn   = document.getElementById('svc-hero-search-btn');
+
+    if (input) input.setAttribute('placeholder', 'Search by service or keyword (e.g., Software, Device, SharePoint)…');
+
+    if (btn && form) {
+      btn.addEventListener('click', function () {
+        if (input && !input.value.trim()) { input.focus(); return; }
+        if (typeof form.requestSubmit === 'function') form.requestSubmit();
+        else form.submit();
+      });
+    }
+  })();
+</script>
+
+<!-- Catalog enhancements (tooltips, category text, search removal) and
+     category-swap skeleton hiding now live in src/svcCatalogEnhancements.js
+     (bundled into script.js) since neither depends on server-rendered
+     Curlybars data. Do not re-add them inline. -->
+
+<!-- Catalog reveal controller. The hero is static, fully-styled markup and is
+     visible immediately (no hide-by-default guard); only the async service
+     catalog is gated. This swaps the skeleton for the real catalog
+     (.svc-cat-ready) once it is complete. (.svc-ready is now a harmless no-op,
+     kept only so existing callers don't need touching.)
+     Shared reveal-on-complete controller lives in src/svcReveal.js
+     (window.initSvcRevealOnComplete), consistent with service_page.hbs's
+     form-skeleton reveal. SAFETY: 6s JS hard cap + 6.5s CSS failsafe +
+     instant reveal on bfcache. -->
+<script>
+  (function () {
+    var root = document.documentElement;
+
+    // Reveal the hero immediately once the page is interactive — the hero is
+    // our own fully-styled markup, so there's no reason to hold it for the
+    // catalog. Holding only the catalog behind its skeleton avoids the flash
+    // while keeping the greeting snappy.
+    function revealHero() { root.classList.add('svc-ready'); }
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', revealHero);
+    } else {
+      revealHero();
+    }
+    window.addEventListener('pageshow', function (e) { if (e.persisted) revealHero(); });
+
+    var config = {
+      targetId: 'service-catalog-main-content',
+      skeletonId: 'svc-catalog-skeleton',
+      skeletonHideClass: 'svc-cat-skel-hide',
+      readyClasses: ['svc-cat-ready'],
+      // "Complete" = the catalog has real service links rendered.
+      isComplete: function (main) {
+        return !!main.querySelector('a[href*="/services/"]');
+      }
+    };
+    // script.js (which defines window.initSvcRevealOnComplete) is a classic
+    // script whose load order relative to this inline block isn't
+    // guaranteed, so poll briefly instead of assuming it has already run.
+    function tryInit() {
+      if (typeof window.initSvcRevealOnComplete === 'function') {
+        window.initSvcRevealOnComplete(config);
+        return true;
+      }
+      return false;
+    }
+    if (!tryInit()) {
+      var attempts = 0;
+      var iv = setInterval(function () {
+        attempts++;
+        if (tryInit() || attempts > 100) clearInterval(iv);
+      }, 20);
+    }
+  })();
+</script>
+{{/if}}

--- a/templates/service_list_page.hbs
+++ b/templates/service_list_page.hbs
@@ -215,7 +215,7 @@
     var input = wrap.querySelector('input[type="search"]');
     var btn   = document.getElementById('svc-hero-search-btn');
 
-    if (input) input.setAttribute('placeholder', 'Search by service, topic, or keyword (e.g., Software, Device, Sharepoint)...');
+    if (input) input.setAttribute('placeholder', 'Search by service or keyword (e.g., Software, Device, Sharepoint)...');
 
     if (btn && form) {
       btn.addEventListener('click', function () {

--- a/templates/service_list_page.hbs
+++ b/templates/service_list_page.hbs
@@ -215,7 +215,7 @@
     var input = wrap.querySelector('input[type="search"]');
     var btn   = document.getElementById('svc-hero-search-btn');
 
-    if (input) input.setAttribute('placeholder', 'Search by service or keyword (e.g., Software, Device, Sharepoint)...');
+    if (input) input.setAttribute('placeholder', 'Search by service or keyword (e.g., Software, Device, SharePoint)…');
 
     if (btn && form) {
       btn.addEventListener('click', function () {

--- a/templates/service_list_page.hbs
+++ b/templates/service_list_page.hbs
@@ -215,7 +215,7 @@
     var input = wrap.querySelector('input[type="search"]');
     var btn   = document.getElementById('svc-hero-search-btn');
 
-    if (input) input.setAttribute('placeholder', 'Search by service, topic, or keyword (e.g., Software, Device, Sharepoint, Slack, Password)...');
+    if (input) input.setAttribute('placeholder', 'Search by service, topic, or keyword (e.g., Software, Device, Sharepoint)...');
 
     if (btn && form) {
       btn.addEventListener('click', function () {

--- a/templates/service_list_page.hbs
+++ b/templates/service_list_page.hbs
@@ -215,7 +215,7 @@
     var input = wrap.querySelector('input[type="search"]');
     var btn   = document.getElementById('svc-hero-search-btn');
 
-    if (input) input.setAttribute('placeholder', 'How can we help?');
+    if (input) input.setAttribute('placeholder', 'Search by service, topic, or keyword (e.g., Software, Device, Sharepoint, Slack, Password)...');
 
     if (btn && form) {
       btn.addEventListener('click', function () {

--- a/templates/service_page.hbs
+++ b/templates/service_page.hbs
@@ -183,7 +183,7 @@
     var input = wrap.querySelector('input[type="search"]');
     var btn   = document.getElementById('svc-hero-search-btn');
 
-    if (input) input.setAttribute('placeholder', 'Search services and resources…');
+    if (input) input.setAttribute('placeholder', 'Search by services or keyword...');
 
     if (btn && form) {
       btn.addEventListener('click', function () {

--- a/templates/service_page.hbs
+++ b/templates/service_page.hbs
@@ -183,7 +183,7 @@
     var input = wrap.querySelector('input[type="search"]');
     var btn   = document.getElementById('svc-hero-search-btn');
 
-    if (input) input.setAttribute('placeholder', 'Search by services or keyword...');
+    if (input) input.setAttribute('placeholder', 'Search by service or keyword…');
 
     if (btn && form) {
       btn.addEventListener('click', function () {


### PR DESCRIPTION
## Changes

### Bug Fixes

- **Fixed dropdown rendering behind submit button on service pages** (`style.css`)
  - Removed `position: relative` from `.svc-custom-submit-wrap` which was creating a stacking context that caused form dropdowns to paint behind the submit button
  - Added `position: relative; z-index: 1` to `.svc-form-panel #service-catalog-item` to ensure form content (including dropdowns) always renders above the submit wrap

### UI Improvements — Service Page Search Bar (`style.css`)

- Narrowed the search bar to `max-width: 560px` and centered it
- Added a subtle border (`1px solid #b9c9ef`) and box shadow for visibility against the white background
- Reduced overall height ~20% (smaller padding, `38×38` button, `15px` font)
- Changed the search button color from pink gradient to navy blue (`#003b91`) to match the "Submit a request" button

### Search Placeholder Text Updates

- **`service_list_page.hbs`** — Changed search placeholder from "How can we help?" to "Search by service or keyword (e.g., Software, Device, Sharepoint)..."
- **`service_page.hbs`** — Changed search placeholder from "Search services and resources…" to "Search by services or keyword..."

### Files Modified

- `style.css`
- `templates/service_list_page.hbs`
- `templates/service_page.hbs`