### PR TITLE
fix(header): scope mobile-nav hide rule to desktop breakpoint

### DIFF
--- a/style.css
+++ b/style.css
@@ -7959,10 +7959,11 @@ html.svc-home .header .search-wrapper {
   align-items: center !important;
 }
 
-.header > .nav-wrapper-mobile {
-  display: none !important;
+@media (min-width: 769px) {
+  .header > .nav-wrapper-mobile {
+    display: none !important;
+  }
 }
-
 @media (max-width: 768px) {
   .header > .nav-wrapper-desktop {
     display: flex !important;

--- a/styles/_svc-header.scss
+++ b/styles/_svc-header.scss
@@ -219,8 +219,16 @@ html.svc-home .header .search-wrapper {
   align-items: center !important;
 }
 
-.header > .nav-wrapper-mobile {
-  display: none !important;
+// Desktop-only: hide the mobile hamburger nav above the 768px breakpoint.
+// Must stay scoped to a media query — an unscoped `!important` here has the
+// same specificity as (and previously overrode, via later source order) the
+// `@media (max-width: 768px) { .header .nav-wrapper-mobile { display: flex } }`
+// rule above, which permanently hid the mobile hamburger button at every
+// viewport width.
+@media (min-width: 769px) {
+  .header > .nav-wrapper-mobile {
+    display: none !important;
+  }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Problem

Investigating a report that the header user-name (`[data-user-name]`) was still visible at 555px+ in `sandbox`. Verified via a headless-browser check (Chromium, actual built `style.css` + `templates/header.hbs` markup) across 400–1200px widths that the username-hiding rule in `_svc-header.scss` is correct and already live on `sandbox` (added in `c420e0f`) — hidden 400–768px, shown 900px.

While verifying, I found a real, related bug in the same file:

```scss
.header > .nav-wrapper-mobile {
  display: none !important;
}
```

This rule was **unscoped** (no media query), so it had the same specificity as the `@media (max-width: 768px) { .header .nav-wrapper-mobile { display: flex !important; } }` rule meant to show the hamburger nav on mobile — and since it appeared later in source order, it always won. Net effect: the mobile hamburger nav never rendered at **any** viewport width.

## Fix

Scope the hide rule to `@media (min-width: 769px)` so it only hides the mobile nav on desktop widths, leaving the mobile-width rule free to show it.

## Verification

Headless Chromium check against the rebuilt `style.css`, reading `getComputedStyle` at 400/500/555/700/767/768/769/900/1200px:

| width | `[data-user-name]` | `.nav-wrapper-mobile` | `.nav-wrapper-desktop` |
|---|---|---|---|
| 400–768px | `none` | `flex` ✅ (was `none` before fix) | `flex` |
| 769–1200px | `inline` | `none` ✅ | `flex` |

Also ran `yarn build` (rebuilt `style.css`) and `yarn eslint src` (0 errors, only pre-existing warnings).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>