### PR TITLE
fix(home): scope overflow-x:hidden to .svc-home instead of site-wide

### DIFF
--- a/style.css
+++ b/style.css
@@ -6141,7 +6141,7 @@ a.svc-help-btn:hover,
 }
 /* ---------- MOBILE ---------- */
 @media (max-width: 768px) {
-  html, body {
+  html.svc-home, body.svc-home {
     overflow-x: hidden !important;
     max-width: 100% !important;
   }

--- a/styles/_svc-home.scss
+++ b/styles/_svc-home.scss
@@ -492,7 +492,16 @@ a.svc-help-btn:hover,
 
 /* ---------- MOBILE ---------- */
 @media (max-width: 768px) {
-  html, body { overflow-x: hidden !important; max-width: 100% !important; }
+  // Scoped to .svc-home (added to both <html> and <body> by
+  // templates/service_list_page.hbs) — this used to be a bare `html, body`
+  // selector, which applied on *every* page, not just the home page. Since
+  // neither selector is scoped by combinator to an ancestor, `overflow-x:
+  // hidden !important` suppressed the horizontal scrollbar site-wide any
+  // time header content (logo + user-info avatar + mobile hamburger, none
+  // of which shrink) overflowed the viewport, silently clipping whichever
+  // header item sat off the right edge instead of leaving it reachable via
+  // scroll.
+  html.svc-home, body.svc-home { overflow-x: hidden !important; max-width: 100% !important; }
 
   /* Hide only stray/duplicate menu buttons — NOT our real menu button */
   .svc-home .header .mobile-menu-button,


### PR DESCRIPTION
## Problem

Follow-up to #76. After that PR restored the mobile hamburger nav, you reported it (and, earlier, the desktop user-avatar dropdown) still wasn't visible/reachable below certain widths — getting "consumed by the right window border."

Root cause: `_svc-home.scss` has a mobile media query where every rule is correctly scoped to `.svc-home` — **except** one:

```scss
@media (max-width: 768px) {
  html, body { overflow-x: hidden !important; max-width: 100% !important; }
  ...
  .svc-home .header .mobile-menu-button, ... { display: none !important; }
}
```

`html, body` (no `.svc-home` ancestor/class qualifier) applies on **every page**, not just the service-catalog home page it was written for. Combined with the header's flex children all being non-shrinking (`flex: 0 0 auto` + `flex-wrap: nowrap` on `.logo`, `.nav-wrapper-desktop`, `.nav-wrapper-mobile` in `_svc-header.scss`), any time header content is wider than the viewport, the overflowing item doesn't wrap or get a scrollbar — it's silently clipped by the edge of the window, because `overflow-x: hidden` on `body` disables the scroll that would otherwise reveal it. That's exactly the "gets consumed by the right window border" and "hamburger isn't visible" symptoms.

## Fix

Scope the rule to `html.svc-home, body.svc-home` — both elements get the `.svc-home` class from `templates/service_list_page.hbs` (`document.documentElement.classList.add('svc-home')` / `document.body.classList.add('svc-home')`), matching every sibling rule in the same block.

## Verification

Headless Chromium check against the rebuilt `style.css`:
- Without `.svc-home` class on html/body (i.e. any other page): `overflow-x: visible` — matches default, no more forced clipping.
- With `.svc-home` class added (home page): `overflow-x: hidden` — unchanged, original intent preserved.

Also ran `yarn build` (rebuilt `style.css`) and `yarn eslint src` (0 errors, only pre-existing warnings).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>