### PR TITLE
fix(search): self-heal duplicated hc path from native instant-search widget

### DIFF
--- a/script.js
+++ b/script.js
@@ -799,6 +799,54 @@
   })();
 
   /*
+   * Corrects a specific class of broken navigation produced by Zendesk's
+   * *native* instant-search widget (the `<zd-autocomplete>` /
+   * `<zd-autocomplete-multibrand>` custom elements rendered by the platform's
+   * own `{{search instant=true}}` helper output on service_list_page.hbs —
+   * this is separate from, and not to be confused with, our own custom
+   * src/svcSearch.js hero/mini search widget).
+   *
+   * That native widget's backing search API returns service-catalog
+   * suggestions with a *relative* URL missing its leading slash, e.g.:
+   *
+   *   { "type": "service_catalog_item", "url": "hc/services/<id>", ... }
+   *
+   * and the widget renders `<a href="{{url}}">` directly from that value.
+   * When a user is on a page served at `/hc/<locale>/services` and clicks
+   * such a suggestion, the browser resolves the relative href against the
+   * current directory, producing `/hc/<locale>/hc/services/<id>` (a 404)
+   * instead of `/hc/<locale>/services/<id>`.
+   *
+   * We can't patch the widget's markup or intercept its clicks: its DOM lives
+   * inside closed shadow roots (`element.shadowRoot` is `null`, and per spec
+   * `event.composedPath()` doesn't reveal nodes inside a closed shadow tree to
+   * listeners outside it), and it's platform code we don't control or bundle.
+   *
+   * Instead, this module self-heals on arrival: it detects the resulting
+   * duplicated `/hc/<locale>/hc/` segment in the URL and redirects to the
+   * corrected path. `/hc/` only ever appears once, at the very start of a
+   * real Help Center path, so this pattern is unambiguous and safe to rewrite
+   * unconditionally, regardless of which route or widget produced it.
+   */
+
+  const DUPLICATED_HC_SEGMENT = /^(\/hc\/[^/]+)\/hc\/(.+)$/;
+
+  function getCorrectedHelpCenterPath(pathname) {
+    const match = DUPLICATED_HC_SEGMENT.exec(pathname || "");
+    return match ? `${match[1]}/${match[2]}` : null;
+  }
+
+  (function redirectIfDuplicatedHelpCenterPath() {
+    var corrected = getCorrectedHelpCenterPath(window.location.pathname);
+    if (!corrected) return;
+    // Run as early as possible (no DOM readiness needed) and use replace()
+    // so the broken URL doesn't linger in browser history.
+    window.location.replace(
+      corrected + window.location.search + window.location.hash
+    );
+  })();
+
+  /*
    * Shared "live search" widget logic for the Service Catalog mini search
    * (service_page.hbs) and hero search (service_list_page.hbs).
    *

--- a/src/fixDuplicatedHelpCenterPath.js
+++ b/src/fixDuplicatedHelpCenterPath.js
@@ -1,0 +1,47 @@
+/*
+ * Corrects a specific class of broken navigation produced by Zendesk's
+ * *native* instant-search widget (the `<zd-autocomplete>` /
+ * `<zd-autocomplete-multibrand>` custom elements rendered by the platform's
+ * own `{{search instant=true}}` helper output on service_list_page.hbs —
+ * this is separate from, and not to be confused with, our own custom
+ * src/svcSearch.js hero/mini search widget).
+ *
+ * That native widget's backing search API returns service-catalog
+ * suggestions with a *relative* URL missing its leading slash, e.g.:
+ *
+ *   { "type": "service_catalog_item", "url": "hc/services/<id>", ... }
+ *
+ * and the widget renders `<a href="{{url}}">` directly from that value.
+ * When a user is on a page served at `/hc/<locale>/services` and clicks
+ * such a suggestion, the browser resolves the relative href against the
+ * current directory, producing `/hc/<locale>/hc/services/<id>` (a 404)
+ * instead of `/hc/<locale>/services/<id>`.
+ *
+ * We can't patch the widget's markup or intercept its clicks: its DOM lives
+ * inside closed shadow roots (`element.shadowRoot` is `null`, and per spec
+ * `event.composedPath()` doesn't reveal nodes inside a closed shadow tree to
+ * listeners outside it), and it's platform code we don't control or bundle.
+ *
+ * Instead, this module self-heals on arrival: it detects the resulting
+ * duplicated `/hc/<locale>/hc/` segment in the URL and redirects to the
+ * corrected path. `/hc/` only ever appears once, at the very start of a
+ * real Help Center path, so this pattern is unambiguous and safe to rewrite
+ * unconditionally, regardless of which route or widget produced it.
+ */
+
+const DUPLICATED_HC_SEGMENT = /^(\/hc\/[^/]+)\/hc\/(.+)$/;
+
+export function getCorrectedHelpCenterPath(pathname) {
+  const match = DUPLICATED_HC_SEGMENT.exec(pathname || "");
+  return match ? `${match[1]}/${match[2]}` : null;
+}
+
+(function redirectIfDuplicatedHelpCenterPath() {
+  var corrected = getCorrectedHelpCenterPath(window.location.pathname);
+  if (!corrected) return;
+  // Run as early as possible (no DOM readiness needed) and use replace()
+  // so the broken URL doesn't linger in browser history.
+  window.location.replace(
+    corrected + window.location.search + window.location.hash
+  );
+})();

--- a/src/fixDuplicatedHelpCenterPath.spec.js
+++ b/src/fixDuplicatedHelpCenterPath.spec.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "@jest/globals";
+import { getCorrectedHelpCenterPath } from "./fixDuplicatedHelpCenterPath";
+
+describe("getCorrectedHelpCenterPath", () => {
+  it("strips the duplicated /hc/<locale>/hc/ segment for a services link", () => {
+    expect(
+      getCorrectedHelpCenterPath(
+        "/hc/en-us/hc/services/01KJZS1V2QCTPM1BR9Q9CWAZE3"
+      )
+    ).toBe("/hc/en-us/services/01KJZS1V2QCTPM1BR9Q9CWAZE3");
+  });
+
+  it("works for other locales and other post-/hc/ routes", () => {
+    expect(getCorrectedHelpCenterPath("/hc/fr/hc/articles/456")).toBe(
+      "/hc/fr/articles/456"
+    );
+    expect(getCorrectedHelpCenterPath("/hc/en-us/hc/approval_requests/9")).toBe(
+      "/hc/en-us/approval_requests/9"
+    );
+  });
+
+  it("preserves a trailing slash", () => {
+    expect(getCorrectedHelpCenterPath("/hc/en-us/hc/services/")).toBe(
+      "/hc/en-us/services/"
+    );
+  });
+
+  it("returns null for a normal, non-duplicated path", () => {
+    expect(
+      getCorrectedHelpCenterPath(
+        "/hc/en-us/services/01KJZS1V2QCTPM1BR9Q9CWAZE3"
+      )
+    ).toBeNull();
+  });
+
+  it("returns null when /hc/ isn't at the start of the path", () => {
+    expect(getCorrectedHelpCenterPath("/something/hc/services/1")).toBeNull();
+  });
+
+  it("returns null for empty/nullish input", () => {
+    expect(getCorrectedHelpCenterPath("")).toBeNull();
+    expect(getCorrectedHelpCenterPath(null)).toBeNull();
+    expect(getCorrectedHelpCenterPath(undefined)).toBeNull();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import "./share";
 import "./search";
 import "./forms";
 import "./domFixups";
+import "./fixDuplicatedHelpCenterPath";
 import "./svcSearch";
 import "./svcGreeting";
 import "./svcReveal";


### PR DESCRIPTION
## Description

Follow-up to #75. That PR fixed the `helpCenterPath`-duplication bug in our own `service-catalog`/`approval-requests` render code, but the same *symptom* (`/hc/<locale>/hc/services/<id>` 404s) kept appearing from the **hero search bar** on the services page — a different root cause entirely.

### Root cause

The hero search box uses Zendesk's *native* instant-search widget (`{{search instant=true}}` on `service_list_page.hbs`), rendered via platform-shipped custom elements `<zd-autocomplete>` / `<zd-autocomplete-multibrand>` (not our own `src/svcSearch.js` or React service-catalog bundle). Its backing search API returns service-catalog suggestions with a **relative URL missing the leading slash**, e.g.:

```json
{ "type": "service_catalog_item", "url": "hc/services/01KJZS1V2QCTPM1BR9Q9CWAZE3", "multibrand": true, ... }
```

The widget renders `<a href="{{url}}">` straight from that value. From `/hc/en-us/services`, the browser resolves the relative href against the current directory, producing `/hc/en-us/hc/services/<id>` instead of `/hc/en-us/services/<id>`.

### Why we can't patch the widget directly

Confirmed via live DOM inspection that `<zd-autocomplete>`/`<zd-autocomplete-multibrand>` use **closed shadow roots** (`element.shadowRoot === null`). Per spec, `event.composedPath()` doesn't reveal nodes inside a closed shadow tree to listeners outside it, so we can't intercept clicks or rewrite the anchor's `href` before navigation — it's platform code we don't control or bundle.

### Fix

Self-heal on arrival instead of trying to prevent it: `src/fixDuplicatedHelpCenterPath.js` detects the resulting duplicated `/hc/<locale>/hc/` segment on page load (this pattern is unambiguous — `/hc/` only ever appears once at the start of a real Help Center path) and immediately `location.replace()`s to the corrected URL. Wired into `src/index.js` so it's bundled into `script.js`, loaded on every page — including the error/404 page this bug actually lands on.

This mirrors the existing "patch platform quirks defensively" convention already used in `src/domFixups.js` (dead breadcrumb links, stray "empty" text).

## Testing

- Added `src/fixDuplicatedHelpCenterPath.spec.js` covering the pure `getCorrectedHelpCenterPath()` URL-rewriting logic (various locales/routes, trailing slash, non-matching paths, empty/nullish input).
- `yarn test` — 76 suites / 605 tests passing.
- `yarn eslint src` — 0 errors (pre-existing unrelated warnings only).
- `yarn build` — succeeds; verified the fix is present in the built `script.js`.

## Checklist

- [x] all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] changes are compatible with RTL direction (pure JS redirect logic, no UI)
- [x] N/A — no UI/accessibility surface changed
- [x] N/A — no browser-specific rendering involved (plain `location.replace`)
- [x] N/A — no responsive/UI surface changed
- [ ] PR is approved by @zendesk/vikings