### PR TITLE
fix(header): one user icon on mobile, hide redundant brand-name span

### DIFF
--- a/style.css
+++ b/style.css
@@ -7697,6 +7697,10 @@ body > pre, body > code, body > .template-name, body > .editor-label {
   order: 1;
 }
 
+.header .logo span {
+  display: none !important;
+}
+
 .header .nav-wrapper-desktop {
   display: flex;
   align-items: center;
@@ -7791,32 +7795,16 @@ html.svc-home .header .search-wrapper {
     gap: 16px;
     padding: 12px 16px;
   }
-  /* Swap: hide desktop nav, show mobile hamburger */
+  /* Swap: hide desktop nav entirely, show mobile hamburger only.
+     .menu-button-mobile already renders the avatar plus a menu containing
+     every .user-info dropdown action (profile/requests/activities/sign
+     out) *and* the nav items that only exist in .nav-wrapper-desktop (Ask
+     AI, Submit a request, Service Catalog). Keeping .user-info visible
+     here duplicated the avatar on-screen and added unshrinkable width to
+     the header (logo + user-info + hamburger, none of which can shrink),
+     which is what pushed content off the right edge below ~612px. */
   .header .nav-wrapper-desktop {
-    display: flex !important;
-    flex: 0 0 auto;
-    order: 2;
-  }
-  .header .nav-wrapper-desktop > *:not(.user-info) {
     display: none !important;
-  }
-  .header .nav-wrapper-desktop .user-info {
-    display: inline-block !important;
-  }
-  .header .nav-wrapper-desktop .user-info .dropdown-toggle .svc-username {
-    display: none !important;
-  }
-  /* Fix B: keep the user dropdown anchored on-screen */
-  .header .nav-wrapper-desktop .user-info {
-    position: relative !important;
-  }
-  .header .nav-wrapper-desktop .dropdown-menu {
-    position: absolute !important;
-    right: 0 !important;
-    left: auto !important;
-    top: calc(100% + 4px) !important;
-    max-width: calc(100vw - 24px) !important;
-    box-sizing: border-box !important;
   }
   .header .nav-wrapper-mobile {
     display: flex !important;
@@ -7966,12 +7954,6 @@ html.svc-home .header .search-wrapper {
 }
 @media (max-width: 768px) {
   .header > .nav-wrapper-desktop {
-    display: flex !important;
-    margin-right: 10px !important;
-  }
-  /* Option A: hide the long email on phones — show avatar + chevron only */
-  .header .nav-wrapper-desktop .user-info .dropdown-toggle .svc-username,
-  .header .nav-wrapper-desktop .user-info [data-user-name] {
     display: none !important;
   }
 }

--- a/styles/_svc-header.scss
+++ b/styles/_svc-header.scss
@@ -7,6 +7,14 @@
   flex: 0 0 auto;
   order: 1;
 }
+// Redundant next to the logo image (and, for this org, long enough — e.g.
+// "Advanced Research Projects Agency for Health - Sandbox" — to be a major
+// contributor to header overflow at narrow widths); hide it everywhere.
+// Controlled by the theme's "Show Help Center name" setting, but even when
+// enabled we don't want it rendered.
+.header .logo span {
+  display: none !important;
+}
 .header .nav-wrapper-desktop {
   display: flex;
   align-items: center;
@@ -86,32 +94,16 @@ html.svc-home .header .search-wrapper {
     gap: 16px;
     padding: 12px 16px;
   }
-  /* Swap: hide desktop nav, show mobile hamburger */
+  /* Swap: hide desktop nav entirely, show mobile hamburger only.
+     .menu-button-mobile already renders the avatar plus a menu containing
+     every .user-info dropdown action (profile/requests/activities/sign
+     out) *and* the nav items that only exist in .nav-wrapper-desktop (Ask
+     AI, Submit a request, Service Catalog). Keeping .user-info visible
+     here duplicated the avatar on-screen and added unshrinkable width to
+     the header (logo + user-info + hamburger, none of which can shrink),
+     which is what pushed content off the right edge below ~612px. */
   .header .nav-wrapper-desktop {
-    display: flex !important;
-    flex: 0 0 auto;
-    order: 2;
-  }
-  .header .nav-wrapper-desktop > *:not(.user-info) {
     display: none !important;
-  }
-  .header .nav-wrapper-desktop .user-info {
-    display: inline-block !important;
-  }
-  .header .nav-wrapper-desktop .user-info .dropdown-toggle .svc-username {
-    display: none !important;
-  }
-  /* Fix B: keep the user dropdown anchored on-screen */
-  .header .nav-wrapper-desktop .user-info {
-    position: relative !important;
-  }
-  .header .nav-wrapper-desktop .dropdown-menu {
-    position: absolute !important;
-    right: 0 !important;
-    left: auto !important;
-    top: calc(100% + 4px) !important;
-    max-width: calc(100vw - 24px) !important;
-    box-sizing: border-box !important;
   }
   .header .nav-wrapper-mobile { display: flex !important; align-items: center; }
   .header .menu-button-mobile { display: inline-flex !important; align-items: center; gap: 8px; }
@@ -232,13 +224,11 @@ html.svc-home .header .search-wrapper {
 }
 
 @media (max-width: 768px) {
+  // .nav-wrapper-desktop (and the .user-info avatar dropdown it contains)
+  // is fully hidden on mobile above in the "Swap" block — .menu-button-mobile
+  // is the one user icon shown here, so there's nothing left to anchor or
+  // hide the username inside .user-info for.
   .header > .nav-wrapper-desktop {
-    display: flex !important;
-    margin-right: 10px !important;
-  }
-  /* Option A: hide the long email on phones — show avatar + chevron only */
-  .header .nav-wrapper-desktop .user-info .dropdown-toggle .svc-username,
-  .header .nav-wrapper-desktop .user-info [data-user-name] {
     display: none !important;
   }
 }


### PR DESCRIPTION
## Problem

Follow-up to #76 and #77. After those merged, you reported: (1) every page shows a duplicate avatar in mobile view, (2) content still starts getting clipped by the right window edge below ~612px, and (3) the logo's brand-name `<span>` (e.g. `"Advanced Research Projects Agency for Health - Sandbox"`) should be hidden everywhere — it's redundant next to the logo image.

## Root cause

`.nav-wrapper-desktop` (the `.user-info` avatar dropdown) was being kept *visible* on mobile (`display: inline-block !important`) at the same time `.nav-wrapper-mobile` (the hamburger) was shown. But `.menu-button-mobile` already renders its own avatar image, plus its menu (`.menu-list-mobile`) already contains every action from `.user-info`'s dropdown *and* the nav items that only exist in `.nav-wrapper-desktop` (Ask AI, Submit a request, Service Catalog). So mobile was showing two avatars, and the header now had the brand-name span + two independently non-shrinking avatar-bearing elements (`flex: 0 0 auto` everywhere, `flex-wrap: nowrap`) — that's what kept pushing content off the right edge at narrow widths, matching the "HEADER FINAL: **one user icon**" comment that the code wasn't actually honoring.

## Fix

- `.nav-wrapper-desktop` is now fully `display: none` at `max-width: 768px` (was: hide everything *except* `.user-info`). Removed the now-dead "Fix B" dropdown-menu anchoring and username-hiding rules that only applied to the now-always-hidden `.user-info` on mobile.
- Added `.header .logo span { display: none !important; }` (unconditional, all pages/all widths) to hide the brand-name span.

## Verification

Headless Chromium check using the actual reported help-center name string, at 320–1200px:
- Brand-name span: `display: none` at every width.
- `.nav-wrapper-desktop`/`.nav-wrapper-mobile` toggle exclusively at the 768px breakpoint (no more simultaneous display).
- `header.scrollWidth > viewport width` (overflow) is `false` at every tested width, including 320px — no more clipping.

Also ran `yarn build` and `yarn eslint src` (0 errors, only pre-existing warnings).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>