### PR TITLE
fix(search): eliminate 404 flash and cover service_page.hbs duplicate-path shape

### DIFF
--- a/script.js
+++ b/script.js
@@ -802,45 +802,66 @@
    * Corrects a specific class of broken navigation produced by Zendesk's
    * *native* instant-search widget (the `<zd-autocomplete>` /
    * `<zd-autocomplete-multibrand>` custom elements rendered by the platform's
-   * own `{{search instant=true}}` helper output on service_list_page.hbs —
-   * this is separate from, and not to be confused with, our own custom
-   * src/svcSearch.js hero/mini search widget).
+   * own `{{search instant=true}}` helper output — used on both
+   * service_list_page.hbs and service_page.hbs — this is separate from, and
+   * not to be confused with, our own custom src/svcSearch.js hero/mini search
+   * widget).
    *
    * That native widget's backing search API returns service-catalog
    * suggestions with a *relative* URL missing its leading slash, e.g.:
    *
    *   { "type": "service_catalog_item", "url": "hc/services/<id>", ... }
    *
-   * and the widget renders `<a href="{{url}}">` directly from that value.
-   * When a user is on a page served at `/hc/<locale>/services` and clicks
-   * such a suggestion, the browser resolves the relative href against the
-   * current directory, producing `/hc/<locale>/hc/services/<id>` (a 404)
-   * instead of `/hc/<locale>/services/<id>`.
+   * and the widget renders `<a href="{{url}}">` directly from that value. The
+   * browser resolves that relative href against whatever directory the user
+   * happened to be in when they clicked it, so the resulting broken path
+   * differs by page:
+   *
+   *   - from /hc/<locale>/services            -> /hc/<locale>/hc/services/<id>
+   *   - from /hc/<locale>/services/<other-id> -> /hc/<locale>/services/hc/services/<id>
+   *
+   * In both cases a *second* `/hc/` segment appears somewhere after the
+   * legitimate leading `/hc/<locale>/` prefix — something that can never
+   * happen in a real Help Center path, since `/hc/` only ever appears once,
+   * right at the start. getCorrectedHelpCenterPath() below finds the LAST
+   * `/hc/` occurrence (to also self-heal any further-compounded case) and
+   * treats everything after it as the widget's real intended destination,
+   * reconstructed under the current locale.
    *
    * We can't patch the widget's markup or intercept its clicks: its DOM lives
    * inside closed shadow roots (`element.shadowRoot` is `null`, and per spec
    * `event.composedPath()` doesn't reveal nodes inside a closed shadow tree to
    * listeners outside it), and it's platform code we don't control or bundle.
    *
-   * Instead, this module self-heals on arrival: it detects the resulting
-   * duplicated `/hc/<locale>/hc/` segment in the URL and redirects to the
-   * corrected path. `/hc/` only ever appears once, at the very start of a
-   * real Help Center path, so this pattern is unambiguous and safe to rewrite
-   * unconditionally, regardless of which route or widget produced it.
+   * The *primary* fix lives in templates/document_head.hbs: a tiny inline
+   * `<script>`, duplicating just this check, runs synchronously at the very
+   * top of `<head>` (before any `<body>` content is parsed/painted), so the
+   * redirect happens with no visible flash of the broken page. This module is
+   * the tested, canonical implementation of that same logic (see
+   * fixDuplicatedHelpCenterPath.spec.js) and also ships in script.js as a
+   * defense-in-depth fallback in case the inline guard is ever skipped. Keep
+   * both copies of the algorithm in sync if it ever changes.
    */
 
-  const DUPLICATED_HC_SEGMENT = /^(\/hc\/[^/]+)\/hc\/(.+)$/;
-
   function getCorrectedHelpCenterPath(pathname) {
-    const match = DUPLICATED_HC_SEGMENT.exec(pathname || "");
-    return match ? `${match[1]}/${match[2]}` : null;
+    if (!pathname) return null;
+    var firstSegmentMatch = /^\/hc\/([^/]+)\//.exec(pathname);
+    if (!firstSegmentMatch) return null;
+    var locale = firstSegmentMatch[1];
+    var lastHcIndex = pathname.lastIndexOf("/hc/");
+    if (lastHcIndex <= 0) return null;
+    var rest = pathname.slice(lastHcIndex + "/hc/".length);
+    if (!rest) return null;
+    var corrected = "/hc/" + locale + "/" + rest;
+    return corrected === pathname ? null : corrected;
   }
 
   (function redirectIfDuplicatedHelpCenterPath() {
+    // Fallback only - the inline guard in document_head.hbs handles this
+    // first, with no flash, on every real page load. This still runs in case
+    // that inline script is ever skipped.
     var corrected = getCorrectedHelpCenterPath(window.location.pathname);
     if (!corrected) return;
-    // Run as early as possible (no DOM readiness needed) and use replace()
-    // so the broken URL doesn't linger in browser history.
     window.location.replace(
       corrected + window.location.search + window.location.hash
     );

--- a/src/fixDuplicatedHelpCenterPath.js
+++ b/src/fixDuplicatedHelpCenterPath.js
@@ -2,45 +2,66 @@
  * Corrects a specific class of broken navigation produced by Zendesk's
  * *native* instant-search widget (the `<zd-autocomplete>` /
  * `<zd-autocomplete-multibrand>` custom elements rendered by the platform's
- * own `{{search instant=true}}` helper output on service_list_page.hbs —
- * this is separate from, and not to be confused with, our own custom
- * src/svcSearch.js hero/mini search widget).
+ * own `{{search instant=true}}` helper output — used on both
+ * service_list_page.hbs and service_page.hbs — this is separate from, and
+ * not to be confused with, our own custom src/svcSearch.js hero/mini search
+ * widget).
  *
  * That native widget's backing search API returns service-catalog
  * suggestions with a *relative* URL missing its leading slash, e.g.:
  *
  *   { "type": "service_catalog_item", "url": "hc/services/<id>", ... }
  *
- * and the widget renders `<a href="{{url}}">` directly from that value.
- * When a user is on a page served at `/hc/<locale>/services` and clicks
- * such a suggestion, the browser resolves the relative href against the
- * current directory, producing `/hc/<locale>/hc/services/<id>` (a 404)
- * instead of `/hc/<locale>/services/<id>`.
+ * and the widget renders `<a href="{{url}}">` directly from that value. The
+ * browser resolves that relative href against whatever directory the user
+ * happened to be in when they clicked it, so the resulting broken path
+ * differs by page:
+ *
+ *   - from /hc/<locale>/services            -> /hc/<locale>/hc/services/<id>
+ *   - from /hc/<locale>/services/<other-id> -> /hc/<locale>/services/hc/services/<id>
+ *
+ * In both cases a *second* `/hc/` segment appears somewhere after the
+ * legitimate leading `/hc/<locale>/` prefix — something that can never
+ * happen in a real Help Center path, since `/hc/` only ever appears once,
+ * right at the start. getCorrectedHelpCenterPath() below finds the LAST
+ * `/hc/` occurrence (to also self-heal any further-compounded case) and
+ * treats everything after it as the widget's real intended destination,
+ * reconstructed under the current locale.
  *
  * We can't patch the widget's markup or intercept its clicks: its DOM lives
  * inside closed shadow roots (`element.shadowRoot` is `null`, and per spec
  * `event.composedPath()` doesn't reveal nodes inside a closed shadow tree to
  * listeners outside it), and it's platform code we don't control or bundle.
  *
- * Instead, this module self-heals on arrival: it detects the resulting
- * duplicated `/hc/<locale>/hc/` segment in the URL and redirects to the
- * corrected path. `/hc/` only ever appears once, at the very start of a
- * real Help Center path, so this pattern is unambiguous and safe to rewrite
- * unconditionally, regardless of which route or widget produced it.
+ * The *primary* fix lives in templates/document_head.hbs: a tiny inline
+ * `<script>`, duplicating just this check, runs synchronously at the very
+ * top of `<head>` (before any `<body>` content is parsed/painted), so the
+ * redirect happens with no visible flash of the broken page. This module is
+ * the tested, canonical implementation of that same logic (see
+ * fixDuplicatedHelpCenterPath.spec.js) and also ships in script.js as a
+ * defense-in-depth fallback in case the inline guard is ever skipped. Keep
+ * both copies of the algorithm in sync if it ever changes.
  */
 
-const DUPLICATED_HC_SEGMENT = /^(\/hc\/[^/]+)\/hc\/(.+)$/;
-
 export function getCorrectedHelpCenterPath(pathname) {
-  const match = DUPLICATED_HC_SEGMENT.exec(pathname || "");
-  return match ? `${match[1]}/${match[2]}` : null;
+  if (!pathname) return null;
+  var firstSegmentMatch = /^\/hc\/([^/]+)\//.exec(pathname);
+  if (!firstSegmentMatch) return null;
+  var locale = firstSegmentMatch[1];
+  var lastHcIndex = pathname.lastIndexOf("/hc/");
+  if (lastHcIndex <= 0) return null;
+  var rest = pathname.slice(lastHcIndex + "/hc/".length);
+  if (!rest) return null;
+  var corrected = "/hc/" + locale + "/" + rest;
+  return corrected === pathname ? null : corrected;
 }
 
 (function redirectIfDuplicatedHelpCenterPath() {
+  // Fallback only - the inline guard in document_head.hbs handles this
+  // first, with no flash, on every real page load. This still runs in case
+  // that inline script is ever skipped.
   var corrected = getCorrectedHelpCenterPath(window.location.pathname);
   if (!corrected) return;
-  // Run as early as possible (no DOM readiness needed) and use replace()
-  // so the broken URL doesn't linger in browser history.
   window.location.replace(
     corrected + window.location.search + window.location.hash
   );

--- a/src/fixDuplicatedHelpCenterPath.spec.js
+++ b/src/fixDuplicatedHelpCenterPath.spec.js
@@ -2,10 +2,18 @@ import { describe, it, expect } from "@jest/globals";
 import { getCorrectedHelpCenterPath } from "./fixDuplicatedHelpCenterPath";
 
 describe("getCorrectedHelpCenterPath", () => {
-  it("strips the duplicated /hc/<locale>/hc/ segment for a services link", () => {
+  it("strips the duplicated /hc/<locale>/hc/ segment for a services link (service_list_page.hbs shape)", () => {
     expect(
       getCorrectedHelpCenterPath(
         "/hc/en-us/hc/services/01KJZS1V2QCTPM1BR9Q9CWAZE3"
+      )
+    ).toBe("/hc/en-us/services/01KJZS1V2QCTPM1BR9Q9CWAZE3");
+  });
+
+  it("strips a duplicated /hc/ segment nested deeper in the path (service_page.hbs shape)", () => {
+    expect(
+      getCorrectedHelpCenterPath(
+        "/hc/en-us/services/01KJZQZ73Q8GF00C22QS8FVR83/hc/services/01KJZS1V2QCTPM1BR9Q9CWAZE3"
       )
     ).toBe("/hc/en-us/services/01KJZS1V2QCTPM1BR9Q9CWAZE3");
   });
@@ -16,6 +24,12 @@ describe("getCorrectedHelpCenterPath", () => {
     );
     expect(getCorrectedHelpCenterPath("/hc/en-us/hc/approval_requests/9")).toBe(
       "/hc/en-us/approval_requests/9"
+    );
+  });
+
+  it("self-heals even if the duplication somehow compounds more than once", () => {
+    expect(getCorrectedHelpCenterPath("/hc/en-us/hc/hc/services/1")).toBe(
+      "/hc/en-us/services/1"
     );
   });
 

--- a/templates/document_head.hbs
+++ b/templates/document_head.hbs
@@ -1,3 +1,41 @@
+<!--
+  Zero-flash guard against a specific broken-navigation bug: Zendesk's
+  native instant-search widget (the platform's own `<zd-autocomplete>` /
+  `<zd-autocomplete-multibrand>` custom elements behind the native "search"
+  template helper's instant-search mode, used on service_list_page.hbs and
+  service_page.hbs) returns service-catalog suggestions with a *relative*
+  URL missing its leading slash (e.g. "hc/services/<id>"). Clicking one
+  makes the browser resolve it against whatever directory the user was in,
+  producing a duplicated "/hc/" segment somewhere in the path (shape
+  differs by page, e.g. /hc/<locale>/hc/services/<id> or
+  /hc/<locale>/services/<other-id>/hc/services/<id>) and landing on a 404.
+
+  We can't patch that widget directly - its DOM lives in closed shadow
+  roots we have no access to (see src/fixDuplicatedHelpCenterPath.js for
+  the full writeup and the tested/canonical version of this same check).
+  This inline copy exists ONLY so the redirect can run synchronously,
+  before the browser parses/paints any <body> content, avoiding a visible
+  flash of the broken page. It must stay a plain, dependency-free snippet
+  (no bundle, no asset helper) to guarantee it runs first. Keep this in sync
+  with getCorrectedHelpCenterPath() in fixDuplicatedHelpCenterPath.js/.spec.js
+  if the algorithm ever changes.
+-->
+<script type="text/javascript">
+  (function () {
+    var pathname = window.location.pathname;
+    var firstSegmentMatch = /^\/hc\/([^/]+)\//.exec(pathname);
+    if (!firstSegmentMatch) return;
+    var locale = firstSegmentMatch[1];
+    var lastHcIndex = pathname.lastIndexOf("/hc/");
+    if (lastHcIndex <= 0) return;
+    var rest = pathname.slice(lastHcIndex + "/hc/".length);
+    if (!rest) return;
+    var corrected = "/hc/" + locale + "/" + rest;
+    if (corrected === pathname) return;
+    window.location.replace(corrected + window.location.search + window.location.hash);
+  })();
+</script>
+
 <!-- Customized 5-21-25 -->
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
 


### PR DESCRIPTION
## Description

Follow-up to #78, based on feedback after that fix shipped to sandbox: it worked, but (1) caused a visible flash of the 404 page before redirecting, and (2) the same underlying widget bug was still reproducible from `service_page.hbs` (individual service item pages), not just `service_list_page.hbs`.

### 1. Eliminating the flash

The previous fix only ran from the bundled `script.js`, which loads near the end of `<body>` (standard Zendesk theme convention — we don't control its position). By the time it executed, the browser had already parsed/painted the 404 page's content for at least a frame.

This adds a tiny, dependency-free, synchronous `<script>` as the very first thing in `templates/document_head.hbs` (i.e. inside `<head>`, before any `<body>` content exists to parse or paint). It duplicates just the URL-correction check so it can run with zero build/module dependencies, immediately as the HTML streams in — before the browser ever paints the broken page. `src/fixDuplicatedHelpCenterPath.js` (still bundled into `script.js`) remains as a documented, unit-tested, defense-in-depth fallback in case the inline guard is ever skipped for some reason; both copies are cross-referenced in comments so they're kept in sync.

### 2. Covering service_page.hbs

`service_page.hbs` (an individual service item page, served at `/hc/<locale>/services/<id>`) has the same native `{{search instant=true}}` widget as the list page. Clicking a suggestion there produces a *differently shaped* duplicate further into the path, e.g.:

```
/hc/<locale>/services/<other-id>/hc/services/<id>
```

...which the old regex (anchored to `/hc/<locale>/hc/`) didn't match. `getCorrectedHelpCenterPath()` is now a general "find the last `/hc/` occurrence and reconstruct from there" algorithm, which self-heals both shapes (and any further-compounded case) under one implementation, regardless of which page/route produced the duplicate.

## Testing

- `src/fixDuplicatedHelpCenterPath.spec.js` — 8 tests, including the new `service_page.hbs` shape and a compounded-duplicate edge case.
- `yarn test` — 75 suites / 601 tests passing.
- `yarn eslint src` — 0 errors (pre-existing unrelated warnings only).
- `yarn build` — succeeds; verified the generalized algorithm is present in the built `script.js`.
- Verified the new inline `<head>` script contains no literal Curlybars mustache syntax (rewrote a first draft that accidentally included `{{search instant=true}}` and `{{asset}}` in prose comments, since Curlybars doesn't respect HTML comment boundaries — no local Curlybars validator is available, so erred on the side of caution).

## Checklist

- [x] all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] N/A — no UI/accessibility surface changed (pure redirect logic)
- [x] N/A — no visual changes
- [x] N/A — no browser-specific rendering involved (plain `location.replace`)
- [x] N/A — no responsive/UI surface changed
- [ ] PR is approved by @zendesk/vikings