### PR TITLE
Preserve per-environment theme settings across deploys

### DIFF
--- a/.github/workflows/scripts/updateTheme.js
+++ b/.github/workflows/scripts/updateTheme.js
@@ -32,6 +32,21 @@ async function zendeskFetch(endpoint, options = {}) {
     return response.json();
 }
 
+async function getLiveThemeId(brandId) {
+    try {
+        const data = await zendeskFetch(`/guide/theming/themes?brand_id=${brandId}`, { method: 'GET' });
+        const themes = data.themes || [];
+        const liveTheme = themes.find(t => t.live);
+        return liveTheme ? liveTheme.id : null;
+    } catch (error) {
+        console.log('::group::Action failed with error');
+        console.log(error.message);
+        console.log('::endgroup::');
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## List Themes Error\n\`\`\`\n${error.message}\n\`\`\``);
+        process.exit(1);
+    }
+}
+
 async function importTheme(brandId) {
     try {
         const data = await zendeskFetch('/guide/theming/jobs/themes/imports', {
@@ -72,6 +87,51 @@ async function importTheme(brandId) {
         console.log(error.message);
         console.log('::endgroup::');
         fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Import Theme Error\n\`\`\`\n${error.message}\n\`\`\``);
+        process.exit(1);
+    }
+}
+
+async function updateTheme(themeId) {
+    try {
+        const data = await zendeskFetch('/guide/theming/jobs/themes/updates', {
+            method: 'POST',
+            body: JSON.stringify({
+                job: {
+                    attributes: {
+                        theme_id: themeId,
+                        // Preserve settings customized per-environment in the Theming Center
+                        // (e.g. service catalog IDs) instead of resetting them to manifest.json defaults.
+                        replace_settings: false,
+                        format: "zip"
+                    }
+                }
+            }),
+        });
+
+        const safeData = {
+            job: {
+                id: data.job.id,
+                status: data.job.status,
+                upload_url: data.job.data.upload.url,
+                upload_parameters: '[REDACTED]'
+            }
+        };
+        console.log('::group::Update Theme Response');
+        const prettyResponse = JSON.stringify(safeData, null, 2);
+        console.log(prettyResponse);
+        console.log('::endgroup::');
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Update Theme Response\n\`\`\`json\n${prettyResponse}\n\`\`\``);
+
+        return {
+            jobId: data.job.id,
+            uploadUrl: data.job.data.upload.url,
+            uploadParameters: data.job.data.upload.parameters
+        };
+    } catch (error) {
+        console.log('::group::Action failed with error');
+        console.log(error.message);
+        console.log('::endgroup::');
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Update Theme Error\n\`\`\`\n${error.message}\n\`\`\``);
         process.exit(1);
     }
 }
@@ -185,45 +245,78 @@ async function pruneOldThemes(newThemeId) {
     }
 }
 
-async function run() {
-    try {
-        const { jobId, themeId, uploadUrl, uploadParameters } = await importTheme(brandId);
-        console.log('Job ID:', jobId);
-        console.log('Theme ID:', themeId);
-        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## New Theme ID\n\`${themeId}\``);
+async function waitForJob(jobId, actionLabel) {
+    let jobStatus = await checkJobStatus(jobId);
+    const startTime = Date.now();
+    let attemptInterval = 5000;
 
-        console.log('Uploading theme file...');
-        await uploadThemeFile(uploadUrl, uploadParameters, filePath);
-        console.log('Theme file uploaded.');
-
-        let jobStatus = await checkJobStatus(jobId);
-        const startTime = Date.now();
-        let attemptInterval = 5000;
-
-        while (jobStatus.status !== 'completed' && jobStatus.status !== 'failed') {
-            if (Date.now() - startTime > MAX_WAIT_TIME) {
-                console.error('Job status check timed out');
-                fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Job Status Check Timeout\nJob did not complete within ${MAX_WAIT_TIME / 1000} seconds`);
-                process.exit(1);
-            }
-            console.log('Waiting for import to complete...');
-            await new Promise(resolve => setTimeout(resolve, attemptInterval));
-            jobStatus = await checkJobStatus(jobId);
-            attemptInterval = Math.min(attemptInterval * 1.5, 60000);
-        }
-
-        if (jobStatus.status === 'failed') {
-            console.error('Import failed:', JSON.stringify(jobStatus.errors, null, 2));
-            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Import Failed\n\`\`\`json\n${JSON.stringify(jobStatus.errors, null, 2)}\n\`\`\``);
+    while (jobStatus.status !== 'completed' && jobStatus.status !== 'failed') {
+        if (Date.now() - startTime > MAX_WAIT_TIME) {
+            console.error('Job status check timed out');
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Job Status Check Timeout\nJob did not complete within ${MAX_WAIT_TIME / 1000} seconds`);
             process.exit(1);
         }
+        console.log(`Waiting for ${actionLabel} to complete...`);
+        await new Promise(resolve => setTimeout(resolve, attemptInterval));
+        jobStatus = await checkJobStatus(jobId);
+        attemptInterval = Math.min(attemptInterval * 1.5, 60000);
+    }
 
-        console.log('Pruning old themes before publish...');
-        await pruneOldThemes(themeId);
+    if (jobStatus.status === 'failed') {
+        console.error(`${actionLabel} failed:`, JSON.stringify(jobStatus.errors, null, 2));
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## ${actionLabel} Failed\n\`\`\`json\n${JSON.stringify(jobStatus.errors, null, 2)}\n\`\`\``);
+        process.exit(1);
+    }
 
-        console.log('Import completed. Publishing theme...');
-        await publishTheme(themeId);
-        console.log('Theme published.');
+    return jobStatus;
+}
+
+async function run() {
+    try {
+        const liveThemeId = await getLiveThemeId(brandId);
+
+        if (liveThemeId) {
+            // Update the existing live theme in place with replace_settings: false so
+            // per-environment settings (e.g. service catalog IDs) set in the Theming
+            // Center aren't reset to the manifest.json defaults on every deploy.
+            console.log('Live theme found:', liveThemeId);
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## Live Theme ID\n\`${liveThemeId}\``);
+
+            const { jobId, uploadUrl, uploadParameters } = await updateTheme(liveThemeId);
+            console.log('Job ID:', jobId);
+
+            console.log('Uploading theme file...');
+            await uploadThemeFile(uploadUrl, uploadParameters, filePath);
+            console.log('Theme file uploaded.');
+
+            await waitForJob(jobId, 'Update');
+            console.log('Theme updated in place. No publish needed — it was already live.');
+
+            console.log('Pruning old themes...');
+            await pruneOldThemes(liveThemeId);
+        } else {
+            // No live theme yet for this brand (e.g. first-time setup) — fall back to
+            // importing a brand-new theme and publishing it.
+            console.log('No live theme found for brand. Falling back to import.');
+
+            const { jobId, themeId, uploadUrl, uploadParameters } = await importTheme(brandId);
+            console.log('Job ID:', jobId);
+            console.log('Theme ID:', themeId);
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `\n\n## New Theme ID\n\`${themeId}\``);
+
+            console.log('Uploading theme file...');
+            await uploadThemeFile(uploadUrl, uploadParameters, filePath);
+            console.log('Theme file uploaded.');
+
+            await waitForJob(jobId, 'Import');
+
+            console.log('Pruning old themes before publish...');
+            await pruneOldThemes(themeId);
+
+            console.log('Import completed. Publishing theme...');
+            await publishTheme(themeId);
+            console.log('Theme published.');
+        }
     } catch (error) {
         console.error('An error occurred:', error);
         process.exit(1);

--- a/manifest.json
+++ b/manifest.json
@@ -473,21 +473,21 @@
           "type": "text",
           "description": "general_request_service_id_description",
           "label": "general_request_service_id_label",
-          "value": "01KT6W4J21065JGC51VMSW8AGB"
+          "value": ""
         },
         {
           "identifier": "general_request_category_id",
           "type": "text",
           "description": "general_request_category_id_description",
           "label": "general_request_category_id_label",
-          "value": "01KP3TEETSJKEPJ08CSK7MJG41"
+          "value": ""
         },
-         {
+        {
           "identifier": "other_request_service_id",
           "type": "text",
           "description": "other_request_service_id_description",
           "label": "other_request_service_id_label",
-          "value": "01KX417CKM31JC6K7JBXYB0P7C"
+          "value": ""
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Removes hardcoded per-environment Zendesk service catalog IDs (`general_request_service_id`, `general_request_category_id`, `other_request_service_id`) from `manifest.json`, resetting them to empty defaults so they aren't cloned system to system.
- Updates `.github/workflows/scripts/updateTheme.js` to use the Zendesk **Theme Update Job** (`POST /guide/theming/jobs/themes/updates`, `replace_settings: false`) against the brand's existing live theme instead of always calling the **Theme Import Job**, which previously created a brand-new theme from `manifest.json` defaults on every deploy and wiped out any values customized per-environment in the Theming Center Settings panel.
- Falls back to the original import + publish flow if no live theme exists yet for the brand (first-time setup).

## Why
Import Job creates a fresh theme object from `manifest.json` defaults and publishes it live every deploy, so any Settings-panel value set manually (e.g. the service catalog IDs) got reset on the next push. Update Job with `replace_settings: false` updates templates/assets in place while preserving existing settings, so per-environment values set once in the Theming Center will now persist across builds.

## Follow-up
After this merges, each environment (sandbox/prod) will need the three service catalog IDs re-entered once in the Theming Center Settings panel, since they're now blank in the manifest.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>