### PR TITLE
Fix theme version bump for Update Job deploys

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -72,12 +72,18 @@ jobs:
         run: |
           VERSION=$(node -p "require('./manifest.json').version.split('.').slice(0,2).join('.')")
           BRANCH="${TARGET_BRANCH}"
-          THEME_NAME="ARPA-H Theme ${VERSION}.${{ github.run_number }} (${BRANCH})"
+          RUN_NUMBER="${{ github.run_number }}"
+          THEME_NAME="ARPA-H Theme ${VERSION}.${RUN_NUMBER} (${BRANCH})"
           echo "Setting theme name to: ${THEME_NAME}"
+          # The Theme Update Job rejects uploads whose manifest "version" isn't strictly
+          # higher than the currently live theme's version, so bump the patch component
+          # with the ever-increasing run number. This is build-only (not committed back
+          # to git) — the real semantic version is still managed by semantic-release.
           node -e "
             const fs = require('fs');
             const m = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
             m.name = '${THEME_NAME}';
+            m.version = '${VERSION}.${RUN_NUMBER}';
             fs.writeFileSync('manifest.json', JSON.stringify(m, null, 2) + '\n');
           "
 


### PR DESCRIPTION
## Summary
Follow-up to #81. The first sandbox deploy under the new Theme Update Job flow failed with:

```
"message": "New theme version is not higher than existing one",
"code": "InvalidThemeVersion",
"meta": { "version": "4.48.0" }
```

The Zendesk Theme Update Job requires the uploaded manifest's `version` to be strictly higher than the currently live theme's version — a check the old Import Job never enforced (it always created a brand-new theme).

## Fix
The "Set theme version name" step already overwrites manifest.json's `name` field in the ephemeral CI checkout before zipping (never committed back to git). This does the same for `version`, appending the ever-increasing `github.run_number` as the patch component (e.g. `4.48.42`), so every deploy is guaranteed higher than the last regardless of the real committed semantic version. `semantic-release` still fully owns the actual version in git.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>