### PR TITLE
fix: stop custom submit proxy from opening the file picker on services with attachments

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -418,6 +418,15 @@ export function ItemRequestForm({
                 size="large"
                 isStretched
                 type="submit"
+                // Marks the real submit button so the static proxy button in
+                // service_page.hbs (#svc-custom-submit) can find it
+                // unambiguously. Do not remove: a generic `[role="button"]`
+                // selector also matches Garden's FileUpload dropzone (it
+                // hardcodes role="button"), which sits earlier in the DOM
+                // when an attachments field is configured and was
+                // previously matched first, causing the proxy to open the
+                // file picker instead of submitting the form.
+                data-svc-native-submit
                 disabled={isPreviewMode}
                 title={
                   isPreviewMode

--- a/templates/service_page.hbs
+++ b/templates/service_page.hbs
@@ -345,7 +345,17 @@
 
     function getNativeSubmit() {
       if (!serviceContainer) return null;
-      return serviceContainer.querySelector('button[type="submit"], input[type="submit"], [role="button"]');
+      // [data-svc-native-submit] is set on the real submit Button in
+      // ItemRequestForm.tsx and must be the only selector here. A bare
+      // `[role="button"]` fallback previously matched Garden's FileUpload
+      // dropzone (it hardcodes role="button") whenever a service had an
+      // attachments field, since that dropzone renders earlier in the DOM
+      // than the real submit button. That caused this proxy to open the
+      // OS file picker instead of submitting the form.
+      return (
+        serviceContainer.querySelector('[data-svc-native-submit]') ||
+        serviceContainer.querySelector('button[type="submit"], input[type="submit"]')
+      );
     }
 
     function hideNativeActionArea() {


### PR DESCRIPTION
## Bug

Services with an attachment field would show/behave as if the request form was broken: clicking **Submit a request** silently opened the OS file picker instead of submitting the ticket.

## Root cause

`getNativeSubmit()` in `templates/service_page.hbs` locates the real, React-rendered submit button so the static `#svc-custom-submit` proxy button can click it:

```js
serviceContainer.querySelector('button[type="submit"], input[type="submit"], [role="button"]');
```

Zendesk Garden's `FileUpload` component (used by the `Attachments` field) unconditionally renders with `role="button"` (hardcoded in `@zendeskgarden/react-forms`), and it sits earlier in the DOM (`LeftColumn`/`FieldsContainer`) than the real submit button (`RightColumn`/`ButtonWrapper`). So on any service whose form includes an attachments field, `querySelector`'s first match was the attachments dropzone, not the submit button. Clicking the proxy button then called `.click()` on the dropzone, opening the file picker instead of submitting.

Introduced in 8234346 ("Updating various .hbs files for service catalog theme updates", Alex Maier, 2026-07-17).

## Fix

- Tag the real submit `<Button>` in `ItemRequestForm.tsx` with `data-svc-native-submit`.
- Update `getNativeSubmit()` to prefer that attribute, and drop the ambiguous bare `[role="button"]` fallback (falls back only to `button[type="submit"], input[type="submit"]`).

## Testing

- `yarn test src/modules/service-catalog src/modules/ticket-fields` → 22 suites / 198 tests passing.
- `yarn eslint` on changed files → 0 errors (pre-existing warnings only).
- `tsc --noEmit` → no new errors introduced.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>