### PR TITLE
fix(home): restore visible mobile menu button color on service_list_page

### DIFF
--- a/style.css
+++ b/style.css
@@ -5423,12 +5423,7 @@ html body .header .search-wrapper {
   padding: 7px 14px;
 }
 
-.svc-home .header .ask-ai-icon,
-.svc-home .header .icon-menu {
-  color: #ffffff !important;
-}
-
-.svc-home .header .menu-button-mobile {
+.svc-home .header .ask-ai-icon {
   color: #ffffff !important;
 }
 
@@ -6155,7 +6150,13 @@ a.svc-help-btn:hover,
   .svc-home .header [data-testid*=MobileMenu] {
     display: none !important;
   }
-  /* Show the real mobile menu button on home, styled for the dark hero */
+  /* Show the real mobile menu button on home. NOTE: no forced white color
+     here (unlike a previous version) — the header is transparent and does
+     NOT visually overlap the hero image (they're separate, stacked,
+     non-overlapping elements), so a "styled for the dark hero" white icon
+     was actually white-on-white against the plain page background and
+     invisible. Falls back to the same default (dark, inherited) color
+     every other page already uses successfully. */
   .svc-home .header .nav-wrapper-mobile {
     display: flex !important;
     align-items: center;
@@ -6164,11 +6165,9 @@ a.svc-help-btn:hover,
     display: inline-flex !important;
     align-items: center;
     gap: 8px;
-    color: #ffffff !important;
   }
   .svc-home .header .icon-menu {
     display: inline-flex !important;
-    color: #ffffff !important;
   }
   .svc-home .header .menu-button-mobile .user-avatar {
     width: 28px;

--- a/styles/_svc-home.scss
+++ b/styles/_svc-home.scss
@@ -39,9 +39,16 @@
   border-radius: 1000px;
   padding: 7px 14px;
 }
-.svc-home .header .ask-ai-icon,
-.svc-home .header .icon-menu { color: #ffffff !important; }
-.svc-home .header .menu-button-mobile { color: #ffffff !important; }
+.svc-home .header .ask-ai-icon { color: #ffffff !important; }
+// NOTE: unlike .ask-ai-icon (which sits inside the .ask-ai pill's own
+// rgba(255,255,255,0.12) background, so white always has contrast), the
+// mobile hamburger has no background of its own — it sits directly on
+// .svc-home .header, which is transparent (see top of this file) and is
+// NOT visually overlapping the hero image; the header and hero are
+// separate, stacked, non-overlapping elements. Forcing white here made the
+// hamburger icon and button invisible (white-on-white) against the plain
+// page background. Removed so it falls back to the same default (dark,
+// inherited) color every other page already uses successfully.
 
 /* ---------- HERO ---------- */
 .svc-hero { position: relative; }
@@ -514,7 +521,13 @@ a.svc-help-btn:hover,
     display: none !important;
   }
 
-  /* Show the real mobile menu button on home, styled for the dark hero */
+  /* Show the real mobile menu button on home. NOTE: no forced white color
+     here (unlike a previous version) — the header is transparent and does
+     NOT visually overlap the hero image (they're separate, stacked,
+     non-overlapping elements), so a "styled for the dark hero" white icon
+     was actually white-on-white against the plain page background and
+     invisible. Falls back to the same default (dark, inherited) color
+     every other page already uses successfully. */
   .svc-home .header .nav-wrapper-mobile {
     display: flex !important;
     align-items: center;
@@ -523,11 +536,9 @@ a.svc-help-btn:hover,
     display: inline-flex !important;
     align-items: center;
     gap: 8px;
-    color: #ffffff !important;
   }
   .svc-home .header .icon-menu {
     display: inline-flex !important;
-    color: #ffffff !important;
   }
   .svc-home .header .menu-button-mobile .user-avatar {
     width: 28px;


### PR DESCRIPTION
This pull request updates the header styling on the home page to fix visibility issues with the mobile menu (hamburger) icon. Previously, the icon was forced to white, which made it invisible against the white background. The changes remove this forced color, allowing the icon to use the default inherited color, ensuring proper contrast and consistency with other pages. The forced white color is retained only for the `ask-ai-icon`, which sits on a contrasting background.

Header styling fixes:

* Removed forced white color from `.icon-menu` and `.menu-button-mobile` in both `style.css` and `styles/_svc-home.scss`, allowing the hamburger icon to inherit the default color and remain visible on the home page background. [[1]](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aL5426-R5426) [[2]](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aL6167-L6171) [[3]](diffhunk://#diff-590843e8e838d0d9f249785331b191b865677c700b7bc39ba01532947f067902L42-R51) [[4]](diffhunk://#diff-590843e8e838d0d9f249785331b191b865677c700b7bc39ba01532947f067902L526-L530)
* Updated comments to clarify that the header and hero image are separate, and explain why the forced white color was removed for the hamburger icon. [[1]](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aL6158-R6159) [[2]](diffhunk://#diff-590843e8e838d0d9f249785331b191b865677c700b7bc39ba01532947f067902L517-R530)

Contrast improvements:

* Kept forced white color only for `.ask-ai-icon`, which sits on a semi-transparent background and always has sufficient contrast. [[1]](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aL5426-R5426) [[2]](diffhunk://#diff-590843e8e838d0d9f249785331b191b865677c700b7bc39ba01532947f067902L42-R51)