### PR TITLE
Fix widget blur regression: robust panel detection, correct margin math

### DIFF
--- a/script.js
+++ b/script.js
@@ -1831,19 +1831,39 @@
    * not subject to the same-origin restriction - only its *content* is) - it
    * never reaches into the iframe's content or its cross-origin document.
    *
-   * Zendesk renders the conversation panel in an iframe with id="webWidget"
-   * (kept for backward compatibility across the Classic Web Widget and the
-   * newer Messaging Web Widget). If Zendesk ever renames it, update
-   * WIDGET_PANEL_IFRAME_IDS below.
+   * The Zendesk snippet that actually creates these iframes is configured in
+   * Zendesk Admin Center, not in this repo, so its exact DOM (element IDs)
+   * isn't something we can read from source control or verify against a local
+   * build. Rather than hard-coding a single guessed iframe id (which silently
+   * finds nothing - and shows no blur at all - if Zendesk names it
+   * differently), this identifies the panel iframe with a few independent,
+   * best-effort signals and takes the first match:
+   *
+   *   1. A known id Zendesk has used historically ("webWidget").
+   *   2. Its `src` pointing at a Zendesk widget domain (zdassets.com /
+   *      zendesk.com / zopim.com) - readable on any iframe element regardless
+   *      of cross-origin restrictions, since `src` is just an attribute of
+   *      the outer element in OUR document, not the iframe's cross-origin
+   *      content.
+   *   3. Its accessible name (title/aria-label) mentioning "messag"/"convers"/
+   *      "chat" - matches the launcher's own
+   *      `title="Button to launch messaging window..."` pattern.
+   *
+   * The launcher button itself is explicitly excluded from all of the above so
+   * it's never mistaken for the panel.
    *
    * ES2015 only (no async/await, no optional chaining, no arrow functions in
    * places that would need `this`) - bundled into script.js, which ships
    * without a transpiler.
    */
   (function () {
-    var WIDGET_PANEL_IFRAME_IDS = ["webWidget"];
+    var KNOWN_PANEL_IDS = ["webWidget"];
+    var WIDGET_DOMAIN_PATTERN = /zdassets\.com|zendesk\.com|zopim\.com/i;
+    var MESSAGING_TEXT_PATTERN = /messag|convers|chat/i;
+    var LAUNCHER_TEXT_PATTERN = /launch/i;
     var HALO_MARGIN = 25; // px beyond the tracked iframe's own edges, in any direction
     var LAYER_COUNT = 3;
+    var RECHECK_INTERVAL_MS = 1500; // safety net in case the tracked iframe is swapped out
 
     var haloEl = null;
     var trackedIframe = null;
@@ -1863,11 +1883,39 @@
       return el;
     }
 
+    function accessibleText(el) {
+      return (
+        (el.getAttribute("title") || "") +
+        " " +
+        (el.getAttribute("aria-label") || "")
+      );
+    }
+
+    function isLauncherIframe(el) {
+      if (el.id === "launcher") return true;
+      return LAUNCHER_TEXT_PATTERN.test(accessibleText(el));
+    }
+
+    function looksLikeWidgetPanel(el) {
+      if (WIDGET_DOMAIN_PATTERN.test(el.getAttribute("src") || "")) return true;
+      return MESSAGING_TEXT_PATTERN.test(accessibleText(el));
+    }
+
     function findPanelIframe() {
-      for (var i = 0; i < WIDGET_PANEL_IFRAME_IDS.length; i++) {
-        var el = document.getElementById(WIDGET_PANEL_IFRAME_IDS[i]);
-        if (el && el.tagName === "IFRAME") return el;
+      for (var i = 0; i < KNOWN_PANEL_IDS.length; i++) {
+        var known = document.getElementById(KNOWN_PANEL_IDS[i]);
+        if (known && known.tagName === "IFRAME" && !isLauncherIframe(known)) {
+          return known;
+        }
       }
+
+      var iframes = document.querySelectorAll("iframe");
+      for (var j = 0; j < iframes.length; j++) {
+        var candidate = iframes[j];
+        if (isLauncherIframe(candidate)) continue;
+        if (looksLikeWidgetPanel(candidate)) return candidate;
+      }
+
       return null;
     }
 
@@ -1908,10 +1956,6 @@
         // so the halo tracks smoothly rather than only at the start/end state.
         var ro = new ResizeObserver(scheduleUpdate);
         ro.observe(iframe);
-      } else {
-        // Fallback for browsers without ResizeObserver: cheap low-frequency
-        // poll, only while a panel iframe is present on the page.
-        window.setInterval(scheduleUpdate, 200);
       }
 
       // Catches position-only changes (e.g. a slide-in) that don't necessarily
@@ -1938,8 +1982,24 @@
           startTracking(iframe);
         }
       });
-      bodyObserver.observe(document.body, { childList: true, subtree: false });
+      bodyObserver.observe(document.body, { childList: true, subtree: true });
     }
+
+    // Safety net: browsers without ResizeObserver never get scheduleUpdate
+    // called by size changes, and ANY browser could have its tracked iframe
+    // silently removed/replaced (widget reset, re-init) without our observers
+    // firing. A cheap low-frequency poll re-measures the current iframe and
+    // re-attaches to a replacement if the original one leaves the document.
+    window.setInterval(function () {
+      if (trackedIframe && !document.contains(trackedIframe)) {
+        trackedIframe = null;
+        var replacement = findPanelIframe();
+        if (replacement) startTracking(replacement);
+        else if (haloEl) haloEl.style.display = "none";
+        return;
+      }
+      if (!window.ResizeObserver) scheduleUpdate();
+    }, RECHECK_INTERVAL_MS);
 
     if (document.readyState !== "loading") {
       watchForPanelIframe();

--- a/src/widgetBlurTracker.js
+++ b/src/widgetBlurTracker.js
@@ -14,19 +14,39 @@
  * not subject to the same-origin restriction - only its *content* is) - it
  * never reaches into the iframe's content or its cross-origin document.
  *
- * Zendesk renders the conversation panel in an iframe with id="webWidget"
- * (kept for backward compatibility across the Classic Web Widget and the
- * newer Messaging Web Widget). If Zendesk ever renames it, update
- * WIDGET_PANEL_IFRAME_IDS below.
+ * The Zendesk snippet that actually creates these iframes is configured in
+ * Zendesk Admin Center, not in this repo, so its exact DOM (element IDs)
+ * isn't something we can read from source control or verify against a local
+ * build. Rather than hard-coding a single guessed iframe id (which silently
+ * finds nothing - and shows no blur at all - if Zendesk names it
+ * differently), this identifies the panel iframe with a few independent,
+ * best-effort signals and takes the first match:
+ *
+ *   1. A known id Zendesk has used historically ("webWidget").
+ *   2. Its `src` pointing at a Zendesk widget domain (zdassets.com /
+ *      zendesk.com / zopim.com) - readable on any iframe element regardless
+ *      of cross-origin restrictions, since `src` is just an attribute of
+ *      the outer element in OUR document, not the iframe's cross-origin
+ *      content.
+ *   3. Its accessible name (title/aria-label) mentioning "messag"/"convers"/
+ *      "chat" - matches the launcher's own
+ *      `title="Button to launch messaging window..."` pattern.
+ *
+ * The launcher button itself is explicitly excluded from all of the above so
+ * it's never mistaken for the panel.
  *
  * ES2015 only (no async/await, no optional chaining, no arrow functions in
  * places that would need `this`) - bundled into script.js, which ships
  * without a transpiler.
  */
 (function () {
-  var WIDGET_PANEL_IFRAME_IDS = ["webWidget"];
+  var KNOWN_PANEL_IDS = ["webWidget"];
+  var WIDGET_DOMAIN_PATTERN = /zdassets\.com|zendesk\.com|zopim\.com/i;
+  var MESSAGING_TEXT_PATTERN = /messag|convers|chat/i;
+  var LAUNCHER_TEXT_PATTERN = /launch/i;
   var HALO_MARGIN = 25; // px beyond the tracked iframe's own edges, in any direction
   var LAYER_COUNT = 3;
+  var RECHECK_INTERVAL_MS = 1500; // safety net in case the tracked iframe is swapped out
 
   var haloEl = null;
   var trackedIframe = null;
@@ -46,11 +66,39 @@
     return el;
   }
 
+  function accessibleText(el) {
+    return (
+      (el.getAttribute("title") || "") +
+      " " +
+      (el.getAttribute("aria-label") || "")
+    );
+  }
+
+  function isLauncherIframe(el) {
+    if (el.id === "launcher") return true;
+    return LAUNCHER_TEXT_PATTERN.test(accessibleText(el));
+  }
+
+  function looksLikeWidgetPanel(el) {
+    if (WIDGET_DOMAIN_PATTERN.test(el.getAttribute("src") || "")) return true;
+    return MESSAGING_TEXT_PATTERN.test(accessibleText(el));
+  }
+
   function findPanelIframe() {
-    for (var i = 0; i < WIDGET_PANEL_IFRAME_IDS.length; i++) {
-      var el = document.getElementById(WIDGET_PANEL_IFRAME_IDS[i]);
-      if (el && el.tagName === "IFRAME") return el;
+    for (var i = 0; i < KNOWN_PANEL_IDS.length; i++) {
+      var known = document.getElementById(KNOWN_PANEL_IDS[i]);
+      if (known && known.tagName === "IFRAME" && !isLauncherIframe(known)) {
+        return known;
+      }
     }
+
+    var iframes = document.querySelectorAll("iframe");
+    for (var j = 0; j < iframes.length; j++) {
+      var candidate = iframes[j];
+      if (isLauncherIframe(candidate)) continue;
+      if (looksLikeWidgetPanel(candidate)) return candidate;
+    }
+
     return null;
   }
 
@@ -91,10 +139,6 @@
       // so the halo tracks smoothly rather than only at the start/end state.
       var ro = new ResizeObserver(scheduleUpdate);
       ro.observe(iframe);
-    } else {
-      // Fallback for browsers without ResizeObserver: cheap low-frequency
-      // poll, only while a panel iframe is present on the page.
-      window.setInterval(scheduleUpdate, 200);
     }
 
     // Catches position-only changes (e.g. a slide-in) that don't necessarily
@@ -121,8 +165,24 @@
         startTracking(iframe);
       }
     });
-    bodyObserver.observe(document.body, { childList: true, subtree: false });
+    bodyObserver.observe(document.body, { childList: true, subtree: true });
   }
+
+  // Safety net: browsers without ResizeObserver never get scheduleUpdate
+  // called by size changes, and ANY browser could have its tracked iframe
+  // silently removed/replaced (widget reset, re-init) without our observers
+  // firing. A cheap low-frequency poll re-measures the current iframe and
+  // re-attaches to a replacement if the original one leaves the document.
+  window.setInterval(function () {
+    if (trackedIframe && !document.contains(trackedIframe)) {
+      trackedIframe = null;
+      var replacement = findPanelIframe();
+      if (replacement) startTracking(replacement);
+      else if (haloEl) haloEl.style.display = "none";
+      return;
+    }
+    if (!window.ResizeObserver) scheduleUpdate();
+  }, RECHECK_INTERVAL_MS);
 
   if (document.readyState !== "loading") {
     watchForPanelIframe();

--- a/style.css
+++ b/style.css
@@ -7960,10 +7960,9 @@ html.svc-home .header .search-wrapper {
  * ARPA-Help chat-widget blur backdrops
  * ---------------------------------------------------------------------------
  * The Zendesk messaging launcher button AND the conversation panel it opens
- * both render inside Zendesk's own cross-origin iframes (id="launcher" and
- * id="webWidget") - they are NOT part of this theme and cannot be restyled
- * directly. This was confirmed against Zendesk's full public customization
- * surface for the Messaging Web Widget
+ * both render inside Zendesk's own cross-origin iframes - they are NOT part
+ * of this theme and cannot be restyled directly. This was confirmed against
+ * Zendesk's full public customization surface for the Messaging Web Widget
  * (https://developer.zendesk.com/api-reference/widget-messaging/web/core/,
  * `messenger:set customization` command): it covers theme colors, position/
  * offset, and content toggles, but has no corner-radius or CSS-injection
@@ -7975,9 +7974,12 @@ html.svc-home .header .search-wrapper {
  * radii already used elsewhere in this theme:
  *
  * 1. `.widget-blur-backdrop` - a static halo hugging the closed launcher
- *    button (fixed 64x64 + 16px offset), shaped as a circle
- *    (`border-radius: 50%`) per NEXUS's "Icon Button Drop Shadow" floating-
- *    action-button spec. Reaches exactly 25px beyond the launcher's edges.
+ *    button (fixed 64x64, offset 16px from the screen edges). Reaches
+ *    exactly 25px beyond the launcher's own box on every side - using the
+ *    same uniform "picture-frame" mask technique as the panel halo below
+ *    (not a corner-anchored radial gradient, which would NOT produce a
+ *    uniform margin here since the launcher's own box doesn't touch the
+ *    physical screen corner - it's inset 16px from it).
  *
  * 2. `.widget-blur-backdrop-panel` - a dynamically sized/positioned halo
  *    (see src/widgetBlurTracker.js) that grows to hug the conversation panel
@@ -8005,35 +8007,38 @@ html.svc-home .header .search-wrapper {
 
 .widget-blur-backdrop {
   position: fixed;
-  right: 0;
-  bottom: 0;
-  width: 105px;
-  height: 105px;
-  border-radius: 50%;
+  right: -9px;
+  bottom: -9px;
+  width: 114px;
+  height: 114px;
+  border-radius: 1000px;
   overflow: hidden;
   z-index: 999998;
   pointer-events: none;
 }
 
-.widget-blur-backdrop-layer-1 {
+.widget-blur-backdrop .widget-blur-backdrop-layer-1 {
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
-  mask-image: radial-gradient(circle at 100% 100%, black 0, black 60px, transparent 80px);
-  -webkit-mask-image: radial-gradient(circle at 100% 100%, black 0, black 60px, transparent 80px);
+  mask-image: linear-gradient(to right, transparent, black 17px, black calc(100% - 17px), transparent), linear-gradient(to bottom, transparent, black 17px, black calc(100% - 17px), transparent);
+  mask-composite: intersect;
+  -webkit-mask-image: linear-gradient(to right, transparent, black 17px, black calc(100% - 17px), transparent), linear-gradient(to bottom, transparent, black 17px, black calc(100% - 17px), transparent);
 }
 
-.widget-blur-backdrop-layer-2 {
+.widget-blur-backdrop .widget-blur-backdrop-layer-2 {
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
-  mask-image: radial-gradient(circle at 100% 100%, black 0, black 75px, transparent 95px);
-  -webkit-mask-image: radial-gradient(circle at 100% 100%, black 0, black 75px, transparent 95px);
+  mask-image: linear-gradient(to right, transparent, black 9px, black calc(100% - 9px), transparent), linear-gradient(to bottom, transparent, black 9px, black calc(100% - 9px), transparent);
+  mask-composite: intersect;
+  -webkit-mask-image: linear-gradient(to right, transparent, black 9px, black calc(100% - 9px), transparent), linear-gradient(to bottom, transparent, black 9px, black calc(100% - 9px), transparent);
 }
 
-.widget-blur-backdrop-layer-3 {
+.widget-blur-backdrop .widget-blur-backdrop-layer-3 {
   backdrop-filter: blur(3px);
   -webkit-backdrop-filter: blur(3px);
-  mask-image: radial-gradient(circle at 100% 100%, black 0, black 90px, transparent 105px);
-  -webkit-mask-image: radial-gradient(circle at 100% 100%, black 0, black 90px, transparent 105px);
+  mask-image: linear-gradient(to right, transparent, black 5px, black calc(100% - 5px), transparent), linear-gradient(to bottom, transparent, black 5px, black calc(100% - 5px), transparent);
+  mask-composite: intersect;
+  -webkit-mask-image: linear-gradient(to right, transparent, black 5px, black calc(100% - 5px), transparent), linear-gradient(to bottom, transparent, black 5px, black calc(100% - 5px), transparent);
 }
 
 .widget-blur-backdrop-panel {

--- a/styles/_widget-blur.scss
+++ b/styles/_widget-blur.scss
@@ -2,10 +2,9 @@
  * ARPA-Help chat-widget blur backdrops
  * ---------------------------------------------------------------------------
  * The Zendesk messaging launcher button AND the conversation panel it opens
- * both render inside Zendesk's own cross-origin iframes (id="launcher" and
- * id="webWidget") - they are NOT part of this theme and cannot be restyled
- * directly. This was confirmed against Zendesk's full public customization
- * surface for the Messaging Web Widget
+ * both render inside Zendesk's own cross-origin iframes - they are NOT part
+ * of this theme and cannot be restyled directly. This was confirmed against
+ * Zendesk's full public customization surface for the Messaging Web Widget
  * (https://developer.zendesk.com/api-reference/widget-messaging/web/core/,
  * `messenger:set customization` command): it covers theme colors, position/
  * offset, and content toggles, but has no corner-radius or CSS-injection
@@ -17,9 +16,12 @@
  * radii already used elsewhere in this theme:
  *
  * 1. `.widget-blur-backdrop` - a static halo hugging the closed launcher
- *    button (fixed 64x64 + 16px offset), shaped as a circle
- *    (`border-radius: 50%`) per NEXUS's "Icon Button Drop Shadow" floating-
- *    action-button spec. Reaches exactly 25px beyond the launcher's edges.
+ *    button (fixed 64x64, offset 16px from the screen edges). Reaches
+ *    exactly 25px beyond the launcher's own box on every side - using the
+ *    same uniform "picture-frame" mask technique as the panel halo below
+ *    (not a corner-anchored radial gradient, which would NOT produce a
+ *    uniform margin here since the launcher's own box doesn't touch the
+ *    physical screen corner - it's inset 16px from it).
  *
  * 2. `.widget-blur-backdrop-panel` - a dynamically sized/positioned halo
  *    (see src/widgetBlurTracker.js) that grows to hug the conversation panel
@@ -40,6 +42,8 @@
  * render nothing here (no background of their own), so this degrades safely.
  * ------------------------------------------------------------------------ */
 
+$halo-margin: 25px; // required margin beyond the widget's own edges, in any direction
+
 // Shared base for every blur layer, regardless of which halo it belongs to.
 .widget-blur-backdrop-layer {
   position: absolute;
@@ -47,25 +51,47 @@
   pointer-events: none;
 }
 
+// A uniform-width "picture frame" fade: two perpendicular linear-gradients
+// combined with mask-composite: intersect multiply their alpha together, so
+// the mask is fully opaque over the tracked element's own footprint and
+// fades to transparent over exactly the last $fade-start..edge distance on
+// every side, regardless of the box's width/height. This is what makes the
+// margin genuinely uniform "in any direction" - a radial gradient anchored
+// at a single point cannot do this for a box that isn't itself centered on
+// that point. Standard since Chrome 120, Firefox 53, Safari 15.4
+// (https://caniuse.com/mdn-css_properties_mask-composite).
+@mixin frame-mask($fade-start) {
+  mask-image:
+    linear-gradient(to right, transparent, black #{$fade-start}, black calc(100% - #{$fade-start}), transparent),
+    linear-gradient(to bottom, transparent, black #{$fade-start}, black calc(100% - #{$fade-start}), transparent);
+  mask-composite: intersect;
+  -webkit-mask-image:
+    linear-gradient(to right, transparent, black #{$fade-start}, black calc(100% - #{$fade-start}), transparent),
+    linear-gradient(to bottom, transparent, black #{$fade-start}, black calc(100% - #{$fade-start}), transparent);
+}
+
 // ---------------------------------------------------------------------------
 // 1. Launcher halo (static - the closed launcher button never changes size)
 // ---------------------------------------------------------------------------
-// Launcher footprint is 64px + a 16px offset from the corner = 80px; a 25px
-// margin beyond that on every side gives a 105px square.
-$launcher-reach: 80px; // distance from the viewport corner to the launcher's far edge
-$halo-margin: 25px; // required margin beyond the widget's own edges, in any direction
-$launcher-halo-size: $launcher-reach + $halo-margin; // 105px
+// Launcher box is fixed 64x64, offset 16px from the screen edges. Expanding
+// that box by $halo-margin (25px) on every side gives a 114x114 box offset
+// -9px from the edges (i.e. 9px of it sits past the physical screen edge,
+// which is expected and harmless - there's nothing to blur off-screen).
+$launcher-size: 64px;
+$launcher-offset: 16px;
+$launcher-halo-size: $launcher-size + ($halo-margin * 2); // 114px
+$launcher-halo-offset: $launcher-offset - $halo-margin; // -9px
 
 .widget-blur-backdrop {
   position: fixed;
-  right: 0;
-  bottom: 0;
+  right: $launcher-halo-offset;
+  bottom: $launcher-halo-offset;
   width: $launcher-halo-size;
   height: $launcher-halo-size;
-  // Circle, per NEXUS's "Icon Button Drop Shadow" component spec (used for
-  // floating actions like this one) - the box is a perfect square, so a 50%
-  // radius renders a true circle rather than an arbitrary corner token.
-  border-radius: 50%;
+  // NEXUS corner-radius/round (pill token) - on a square box this renders a
+  // true circle, matching NEXUS's "Icon Button Drop Shadow" floating-action
+  // spec used for round floating buttons like this one.
+  border-radius: 1000px;
   overflow: hidden;
   // Sits above ordinary page content but below the widget iframe's own
   // z-index: 999999 (and below the 2147483647 flash-notification layer, see
@@ -75,27 +101,23 @@ $launcher-halo-size: $launcher-reach + $halo-margin; // 105px
   pointer-events: none;
 }
 
-// Heaviest, tightest blur - right behind the launcher itself.
-.widget-blur-backdrop-layer-1 {
+.widget-blur-backdrop .widget-blur-backdrop-layer-1 {
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
-  mask-image: radial-gradient(circle at 100% 100%, black 0, black #{$launcher-reach - 20px}, transparent #{$launcher-reach});
-  -webkit-mask-image: radial-gradient(circle at 100% 100%, black 0, black #{$launcher-reach - 20px}, transparent #{$launcher-reach});
+  @include frame-mask(17px);
 }
 
-.widget-blur-backdrop-layer-2 {
+.widget-blur-backdrop .widget-blur-backdrop-layer-2 {
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
-  mask-image: radial-gradient(circle at 100% 100%, black 0, black #{$launcher-reach - 5px}, transparent #{$launcher-reach + 15px});
-  -webkit-mask-image: radial-gradient(circle at 100% 100%, black 0, black #{$launcher-reach - 5px}, transparent #{$launcher-reach + 15px});
+  @include frame-mask(9px);
 }
 
-// Lightest, widest reach - fades out exactly at the 25px margin.
-.widget-blur-backdrop-layer-3 {
+// Lightest, widest reach - fades out right at the box's own outer edge.
+.widget-blur-backdrop .widget-blur-backdrop-layer-3 {
   backdrop-filter: blur(3px);
   -webkit-backdrop-filter: blur(3px);
-  mask-image: radial-gradient(circle at 100% 100%, black 0, black #{$launcher-reach + 10px}, transparent #{$launcher-halo-size});
-  -webkit-mask-image: radial-gradient(circle at 100% 100%, black 0, black #{$launcher-reach + 10px}, transparent #{$launcher-halo-size});
+  @include frame-mask(5px);
 }
 
 // ---------------------------------------------------------------------------
@@ -114,32 +136,16 @@ $launcher-halo-size: $launcher-reach + $halo-margin; // 105px
   transition: left 0.12s ease-out, top 0.12s ease-out, width 0.12s ease-out, height 0.12s ease-out;
 }
 
-// A uniform-width "picture frame" fade: two perpendicular linear-gradients
-// combined with mask-composite: intersect multiply their alpha together, so
-// the mask is fully opaque over the panel's own footprint and fades to
-// transparent over exactly the last $halo-margin (25px) on every edge,
-// regardless of the panel's current width/height. Standard since Chrome 120,
-// Firefox 53, Safari 15.4 (https://caniuse.com/mdn-css_properties_mask-composite).
-@mixin panel-frame-mask($fade-start) {
-  mask-image:
-    linear-gradient(to right, transparent, black #{$fade-start}, black calc(100% - #{$fade-start}), transparent),
-    linear-gradient(to bottom, transparent, black #{$fade-start}, black calc(100% - #{$fade-start}), transparent);
-  mask-composite: intersect;
-  -webkit-mask-image:
-    linear-gradient(to right, transparent, black #{$fade-start}, black calc(100% - #{$fade-start}), transparent),
-    linear-gradient(to bottom, transparent, black #{$fade-start}, black calc(100% - #{$fade-start}), transparent);
-}
-
 .widget-blur-backdrop-panel .widget-blur-backdrop-layer-1 {
   backdrop-filter: blur(24px);
   -webkit-backdrop-filter: blur(24px);
-  @include panel-frame-mask(17px);
+  @include frame-mask(17px);
 }
 
 .widget-blur-backdrop-panel .widget-blur-backdrop-layer-2 {
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  @include panel-frame-mask(9px);
+  @include frame-mask(9px);
 }
 
 .widget-blur-backdrop-panel .widget-blur-backdrop-layer-3 {
@@ -149,7 +155,7 @@ $launcher-halo-size: $launcher-reach + $halo-margin; // 105px
   // at the exact same position, producing a hard cut instead of a smooth
   // ramp - use a small positive value so even the widest-reaching, lightest
   // layer still fades in gradually right at the box's outer edge.
-  @include panel-frame-mask(5px);
+  @include frame-mask(5px);
 }
 
 // Respect the "reduce transparency" accessibility preference (Safari/macOS;


### PR DESCRIPTION
## Regression
After merging #88, the blur backdrop stopped being visible around the chat widget (both the closed launcher and the open conversation panel), and the popup no longer read as having a proper rounded/soft edge.

## Root causes found
1. **`src/widgetBlurTracker.js` hard-coded a single guessed iframe id** (`"webWidget"`) for the conversation panel, never verified against a live Zendesk install — the widget snippet is configured in Zendesk Admin Center, not this repo, so its actual DOM structure isn't something I could inspect from source or a local build. If that guess didn't match what Zendesk actually renders, the panel halo silently never attached — **zero blur around the open conversation window**, matching the report exactly.
2. **The launcher halo's mask used a corner-anchored radial gradient**, which only produces a uniform margin for a box that itself touches the anchor point. The launcher sits 16px inset from the screen edges (not flush with the corner), so the radial math didn't actually give a uniform 25px margin in every direction — thinner along the cardinal top/left edges than the diagonal. This is a real geometry bug independent of the detection issue.

## Fix
1. **Robust panel detection** — the tracker now checks three independent, best-effort signals in order: the known id, the iframe's `src` pointing at a Zendesk widget domain (`zdassets.com`/`zendesk.com`/`zopim.com` — readable on any iframe element regardless of cross-origin restrictions, since `src` is just an attribute in *our* document), or an accessible name (`title`/`aria-label`) mentioning "messag"/"convers"/"chat" (mirroring the launcher's own `title="Button to launch messaging window..."` pattern). A body-wide `MutationObserver` (`childList` + `subtree`) keeps watching for the panel iframe to appear, and a periodic safety-net poll re-attaches if the tracked iframe is ever removed/replaced (widget reset/reinit).
2. **Correct launcher halo geometry** — replaced the radial mask with the same uniform "picture-frame" `mask-composite: intersect` technique already used for the panel halo, applied to a static box matching the launcher's real 16/16/64/64 geometry expanded by 25px on every side.

## Verification
- `yarn build` compiles cleanly; new rules/JS confirmed in generated `style.css`/`script.js`.
- `yarn test` — all 593 tests pass.
- `yarn eslint src` — 0 errors (same pre-existing warnings only).
- Headless-Chromium verification: the closed-launcher halo now renders a correctly symmetric circular blur ring (screenshot-checked). A **mock panel iframe identified only by its `title` attribute** (deliberately using neither the known id nor a matching domain, to stress-test the fallback heuristic) was still correctly detected, tracked, and rendered a properly framed blur ring that grows/shrinks with the panel and disappears cleanly when closed.

## Note
Because the actual Zendesk widget snippet lives in Admin Center (not this repo), I can't fully guarantee against every possible DOM shape Zendesk might use — but the new multi-signal detection is far more resilient than a single guessed id. If the panel halo still doesn't appear on the live sandbox site after this merges, the fastest path to a permanent fix is to grab the *actual* panel iframe's opening `<iframe ...>` tag (id/class/title/src) from browser devtools and share it so I can hardcode an exact match.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>