### PR TITLE
Fix required-dropdown validation for non-empty sentinel default values

### DIFF
--- a/styles/_svc-form-validation.scss
+++ b/styles/_svc-form-validation.scss
@@ -82,17 +82,26 @@
 
    NOTE on required dropdowns/comboboxes specifically: unlike text
    inputs, DropDown/MultiSelect/Tagger/LookupField are selection-only
-   (`isEditable={false}`) with a binary value — chosen, or sitting on
-   the empty "-" placeholder — so there is no "typed something,
-   still invalid" interaction to dirty them, and `:user-invalid` can
-   never engage there through any real user action. For those we
-   also match plain `:invalid` while not focused (see the combobox
-   block below), which trades away the "only after interaction"
-   guarantee for that field type: a required dropdown left on "-"
-   will render as invalid as soon as it isn't focused, including at
-   first paint if it's not the initially-focused field. That
-   trade-off is intentional — a chosen/unchosen control has no
-   partial-progress state worth protecting the user from seeing.
+   (`isEditable={false}`) with a binary value — chosen, or not — so
+   there is no "typed something, still invalid" interaction to dirty
+   them, and `:user-invalid` can never engage there through any real
+   user action. Worse, plain `:invalid` can't be trusted either: some
+   ticket-field setups default these fields to a literal "-"
+   placeholder tag rather than a truly empty value (see
+   useItemFormFields.tsx's getFieldValue), and a non-empty string
+   satisfies HTML's `required` constraint regardless of what it means
+   semantically. So for this field family we key off the rendered
+   `<EmptyValueOption/>` marker (fields/EmptyValueOption.tsx) instead
+   — it appears whenever the current value doesn't resolve to a real
+   Option, whether that value is "", "-", or any other non-matching
+   sentinel — gated to `required` fields and to "isn't currently
+   focused" (see the combobox block below). This trades away the
+   "only after interaction" guarantee for that field type: a required
+   dropdown left unselected will render as invalid as soon as it
+   isn't focused, including at first paint if it's not the
+   initially-focused field. That trade-off is intentional — a
+   chosen/unchosen control has no partial-progress state worth
+   protecting the user from seeing.
    ============================================================ */
 
 @mixin svc-invalid-ring($width: 2px) {
@@ -161,24 +170,39 @@
 
     // DropDown/MultiSelect/Tagger all render with `isEditable={false}`
     // (see fields/DropDown.tsx, MultiSelect.tsx, Tagger.tsx) — the
-    // user can only pick from the list, never type into them. Their
-    // value is binary: a real option is selected, or the control
-    // sits on the empty "-" placeholder (EmptyValueOption.tsx / the
-    // renderValue fallback). Picking *anything* on a required field
-    // either fixes it or isn't offered at all — DropDown.tsx only
-    // renders the "-" Option when the field is NOT required — so
-    // there's no "picked something, still invalid" path the way a
-    // text field has, and :user-invalid can structurally never
-    // engage here. We fall back to plain :invalid, gated on "isn't
-    // currently focused" so it doesn't fight the user mid-choice,
-    // to flag a required field still sitting on "-".
+    // user can only pick from the list, never type into them, so
+    // there's no "picked something, still invalid" path a text field
+    // has and :user-invalid can structurally never engage here.
+    //
+    // It also turns out plain :invalid can't be trusted for these
+    // either. A required field's *current value* isn't always a
+    // genuinely empty string: DropDown.tsx/Tagger.tsx compute the
+    // field's default from whichever `custom_field_option` the
+    // backend has flagged `default: true` (see
+    // useItemFormFields.tsx's getFieldValue), and some ticket-field
+    // setups mark a literal "-" placeholder tag as that default
+    // instead of leaving it unset. A non-empty string like "-"
+    // satisfies HTML's `required` constraint just fine (it isn't
+    // empty), so the underlying <input> is natively *valid* and
+    // :invalid never matches, even though nothing meaningful was
+    // chosen.
+    //
+    // What's reliable instead: both components render
+    // <EmptyValueOption/> (fields/EmptyValueOption.tsx, a
+    // `<span aria-hidden="true">-</span>`) as their displayed value
+    // whenever the current value doesn't resolve to a real Option in
+    // the list — which is true whether that value is "", "-", or any
+    // other non-matching sentinel. So we key off that rendered marker
+    // instead of the input's native validity, still gated to
+    // `required` fields and to "isn't currently focused" so it
+    // doesn't fight the user mid-choice.
     //
     // No shake on this one, unlike every rule above: this condition
     // can already be true at first paint, before any interaction at
     // all, if the field defaults to unselected — animating on page
     // load would read as an unearned scold rather than a response
     // to something the user did, so we keep this one static.
-    &:has(input:required:invalid):not(:focus-within) {
+    &:has(input:required):has(span[aria-hidden="true"]):not(:focus-within) {
       @include svc-invalid-ring;
     }
 


### PR DESCRIPTION
This pull request updates the form validation logic and documentation for dropdown-style fields in the `styles/_svc-form-validation.scss` file. The main change is to improve how required dropdowns, multi-selects, and taggers are visually marked as invalid when left unselected, especially in cases where the default value is a placeholder like "-". Instead of relying on the native HTML `:invalid` pseudo-class, which can be unreliable due to placeholder defaults, the code now keys off the presence of a rendered `<EmptyValueOption/>` marker to determine invalid state. This approach ensures more accurate and user-friendly validation feedback for these field types.

**Form validation logic improvements:**

* Updated the documentation to clarify why native HTML validation (`:invalid`) cannot be relied upon for dropdowns, and explained the new approach using the `<EmptyValueOption/>` marker to indicate unselected required fields.
* Changed the CSS selector from `:has(input:required:invalid):not(:focus-within)` to `:has(input:required):has(span[aria-hidden="true"]):not(:focus-within)` to visually mark dropdowns as invalid based on the presence of the empty value marker rather than the native validity state.