### PR TITLE
Gate invalid-field styling strictly on submit attempt, not interaction

### DIFF
--- a/styles/_svc-form-validation.scss
+++ b/styles/_svc-form-validation.scss
@@ -1,5 +1,5 @@
 /* ============================================================
-   ARPA-H custom — "angry" inline validation for the service
+   ARPA-H custom — inline invalid-field styling for the service
    request form (#service-catalog-item inside .svc-form-panel,
    see templates/service_page.hbs).
 
@@ -10,47 +10,36 @@
    highlight the offending control directly, in place, without
    any JS/React changes (CSS only, by design).
 
-   HOW (no JS/monkeypatching required):
-   Every request field already renders a real `required` HTML
-   attribute on its native control — see e.g.
-   src/modules/ticket-fields/fields/Input.tsx (`required={required}`
-   on a Zendesk Garden <Input>, which is a plain <input>), and the
-   same pattern in TextArea.tsx/Checkbox.tsx/DropDown.tsx/
-   MultiSelect.tsx/LookupField.tsx/Tagger.tsx/DatePicker.tsx.
-   ItemRequestForm.tsx sets `noValidate` on the <form>, but
-   `novalidate` only turns off the *browser's own* validation
-   report/submit-blocking step — it does not change a control's
-   underlying constraint-validity, so the standard CSS validity
-   pseudo-classes still reflect it:
-     https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-novalidate
-     https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constraint-validation
-
-   `:user-invalid` (CSS Selectors Level 4) matches a control that
-   fails its constraints only *after the user has interacted with
-   it* — e.g. tabbing/clicking away from an empty required field —
-   which is exactly the "navigate away from an unfilled field"
-   trigger asked for, with zero JS:
-     https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:user-invalid
-   Support is broad in every evergreen browser as of 2026 (Chrome/
-   Edge 119+, Firefox 88+, Safari 16.5+):
-     https://caniuse.com/mdn-css_selectors_user-invalid
-
-   We additionally key off `[aria-invalid="true"]`, which Zendesk
-   Garden's own <Field>/<Input>/<Combobox> already set whenever a
-   `validation="error"` prop reaches them from React (post-submit
-   server-side field errors mapped in ServiceCatalogItem.tsx, and
-   the asset/asset-type/attachments errors from
-   useValidateServiceItemForm.ts) — so every error path, native or
-   server-driven, renders identically.
+   WHEN it lights up: only after the user actually tries to
+   submit, never before. Every rule below keys off
+   `[aria-invalid="true"]`, which Zendesk Garden's own
+   <Field>/<Input>/<Combobox> set whenever a `validation="error"`
+   prop reaches them from React — and that only ever happens in
+   two places, both submit-triggered:
+     - the asset/asset-type/attachments client-side check in
+       useValidateServiceItemForm.ts, run from validateForm() at
+       the top of handleRequestSubmit in ServiceCatalogItem.tsx;
+     - the server's 422 response mapped back onto fields in
+       handleValidationErrors() in the same file, which is also
+       exactly where the "Service couldn't be submitted" toast
+       fires from (notifySubmitError()).
+   Nothing here reacts to blur, typing, or native HTML validity
+   (no `:invalid`/`:user-invalid`) precisely so a field never
+   turns red just because the user tabbed past it or hasn't
+   filled it in yet — only a real submit attempt can set
+   `aria-invalid`, so that's the only thing that can turn a field
+   red. This is an intentional product decision (an earlier
+   interaction-based version of this file used `:invalid`/
+   `:user-invalid` and lit up before submission; that approach
+   was dropped for this reason).
 
    Zendesk Garden's Combobox (used by DropDown/MultiSelect/
    Tagger/LookupField) puts the visible border on the
-   `dropdowns.combobox.trigger` wrapper, while `aria-invalid`/
-   `:user-invalid` land on the (possibly visually-hidden) real
-   <input> nested inside it — so those need the `:has()`
-   relational selector to reach the wrapper. `:has()` has also
-   been supported in every evergreen browser since late 2023
-   (Firefox 121, Chrome 105, Safari 15.4):
+   `dropdowns.combobox.trigger` wrapper, while `aria-invalid`
+   lands on the (visually-hidden) real <input> nested inside it —
+   so that one needs the `:has()` relational selector to reach
+   the wrapper. `:has()` has been supported in every evergreen
+   browser since late 2023 (Firefox 121, Chrome 105, Safari 15.4):
      https://caniuse.com/css-has
 
    ACCESSIBILITY NOTES:
@@ -69,39 +58,19 @@
      looping, so it can't become a persistent distraction and is
      skipped entirely for users who've asked for reduced motion.
 
-   KNOWN LIMITATION: `aria-invalid` can only be toggled by script,
-   so a field that is merely `required` and empty (and has never
-   been through a submit attempt or the asset/attachment
-   client-side check) is flagged *visually* via `:user-invalid`
-   but is not independently announced as "invalid" to screen
-   reader users the moment they leave it — only the pre-existing,
-   already-accessible toast is announced at that point. Closing
-   that last gap would require a small script to mirror
-   `:user-invalid` into `aria-invalid`, which is intentionally out
-   of scope here (SCSS-only fix, per design).
-
-   NOTE on required dropdowns/comboboxes specifically: unlike text
-   inputs, DropDown/MultiSelect/Tagger/LookupField are selection-only
-   (`isEditable={false}`) with a binary value — chosen, or not — so
-   there is no "typed something, still invalid" interaction to dirty
-   them, and `:user-invalid` can never engage there through any real
-   user action. Worse, plain `:invalid` can't be trusted either: some
-   ticket-field setups default these fields to a literal "-"
-   placeholder tag rather than a truly empty value (see
-   useItemFormFields.tsx's getFieldValue), and a non-empty string
-   satisfies HTML's `required` constraint regardless of what it means
-   semantically. So for this field family we key off the rendered
-   `<EmptyValueOption/>` marker (fields/EmptyValueOption.tsx) instead
-   — it appears whenever the current value doesn't resolve to a real
-   Option, whether that value is "", "-", or any other non-matching
-   sentinel — gated to `required` fields and to "isn't currently
-   focused" (see the combobox block below). This trades away the
-   "only after interaction" guarantee for that field type: a required
-   dropdown left unselected will render as invalid as soon as it
-   isn't focused, including at first paint if it's not the
-   initially-focused field. That trade-off is intentional — a
-   chosen/unchosen control has no partial-progress state worth
-   protecting the user from seeing.
+   KNOWN LIMITATION — required dropdowns defaulted to a "-"
+   sentinel: some ticket-field setups default a required dropdown
+   to a literal "-" placeholder tag rather than a truly empty
+   value (see useItemFormFields.tsx's getFieldValue). Whether that
+   renders red after a submit attempt depends entirely on whether
+   Zendesk's backend treats "-" as satisfying the field's
+   required-ness: if the backend accepts it as a real answer, no
+   422/field error ever comes back, `aria-invalid` never gets set,
+   and this field won't render invalid even though nothing
+   meaningful was chosen. Fixing that would mean changing which
+   value the field defaults to (or how "required" is judged),
+   which is app/data logic, not styling — flag it if that turns
+   out to be happening, rather than have CSS guess at it again.
    ============================================================ */
 
 @mixin svc-invalid-ring($width: 2px) {
@@ -117,7 +86,6 @@
   input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]),
   textarea,
   select {
-    &:user-invalid,
     &[aria-invalid="true"] {
       @include svc-invalid-ring;
 
@@ -127,7 +95,6 @@
     }
 
     // Focus indicator must stay visible even while invalid.
-    &:user-invalid:focus-visible,
     &[aria-invalid="true"]:focus-visible {
       box-shadow: 0 0 0 1px var(--svc-error), 0 0 0 1px #0957be inset,
         0 0 3px 1px #0957be !important;
@@ -138,7 +105,6 @@
   // border to read cleanly, so the non-color cue is a dashed
   // (not solid) outline — a shape change, not just a color one.
   input[type="checkbox"] {
-    &:user-invalid,
     &[aria-invalid="true"] {
       outline: 2px dashed var(--svc-error) !important;
       outline-offset: 3px !important;
@@ -148,7 +114,6 @@
       }
     }
 
-    &:user-invalid:focus-visible,
     &[aria-invalid="true"]:focus-visible {
       outline: 2px dashed var(--svc-error) !important;
       box-shadow: 0 0 0 3px #fff, 0 0 0 5px #0957be !important;
@@ -159,7 +124,6 @@
   // select, tagger, lookup): the real invalid <input> is nested
   // and often visually hidden, so target the trigger it lives in. ----
   [data-garden-id="dropdowns.combobox.trigger"] {
-    &:has(input:user-invalid),
     &:has(input[aria-invalid="true"]) {
       @include svc-invalid-ring;
 
@@ -168,45 +132,6 @@
       }
     }
 
-    // DropDown/MultiSelect/Tagger all render with `isEditable={false}`
-    // (see fields/DropDown.tsx, MultiSelect.tsx, Tagger.tsx) — the
-    // user can only pick from the list, never type into them, so
-    // there's no "picked something, still invalid" path a text field
-    // has and :user-invalid can structurally never engage here.
-    //
-    // It also turns out plain :invalid can't be trusted for these
-    // either. A required field's *current value* isn't always a
-    // genuinely empty string: DropDown.tsx/Tagger.tsx compute the
-    // field's default from whichever `custom_field_option` the
-    // backend has flagged `default: true` (see
-    // useItemFormFields.tsx's getFieldValue), and some ticket-field
-    // setups mark a literal "-" placeholder tag as that default
-    // instead of leaving it unset. A non-empty string like "-"
-    // satisfies HTML's `required` constraint just fine (it isn't
-    // empty), so the underlying <input> is natively *valid* and
-    // :invalid never matches, even though nothing meaningful was
-    // chosen.
-    //
-    // What's reliable instead: both components render
-    // <EmptyValueOption/> (fields/EmptyValueOption.tsx, a
-    // `<span aria-hidden="true">-</span>`) as their displayed value
-    // whenever the current value doesn't resolve to a real Option in
-    // the list — which is true whether that value is "", "-", or any
-    // other non-matching sentinel. So we key off that rendered marker
-    // instead of the input's native validity, still gated to
-    // `required` fields and to "isn't currently focused" so it
-    // doesn't fight the user mid-choice.
-    //
-    // No shake on this one, unlike every rule above: this condition
-    // can already be true at first paint, before any interaction at
-    // all, if the field defaults to unselected — animating on page
-    // load would read as an unearned scold rather than a response
-    // to something the user did, so we keep this one static.
-    &:has(input:required):has(span[aria-hidden="true"]):not(:focus-within) {
-      @include svc-invalid-ring;
-    }
-
-    &:has(input:user-invalid):focus-within,
     &:has(input[aria-invalid="true"]):focus-within {
       box-shadow: 0 0 0 1px var(--svc-error), 0 0 0 1px #0957be inset,
         0 0 3px 1px #0957be !important;


### PR DESCRIPTION
## What
PR #91/#97/#98 landed inline invalid-field styling for the service-catalog request form, but it lit fields up via `:invalid`/`:user-invalid` — meaning a field could turn red on blur, or even at first paint, before the user had ever attempted to submit. That's not the intended behavior: nothing should highlight as a validation issue until a real submit attempt happens.

## How
Drops all `:invalid`/`:user-invalid`-based rules (plain text/textarea/checkbox, and the dropdown `EmptyValueOption` fallback from #98). Everything now keys purely off `[aria-invalid="true"]`, which Zendesk Garden only ever sets when React passes a `validation="error"` prop — and that only happens in two places, both triggered from `handleRequestSubmit` in `ServiceCatalogItem.tsx`:
- the asset/asset-type/attachments client-side check (`useValidateServiceItemForm.ts`)
- the server's 422 response mapped back onto fields (`handleValidationErrors`), the same code path that fires the "Service couldn't be submitted" toast

No JS changes — still pure SCSS.

## Verified
Headless Chrome: typing then clearing a required text field, tabbing through a required dropdown, and toggling a checkbox all leave every field neutral with no interaction-based highlighting. Only a field with `aria-invalid="true"` (simulating the post-submit state) renders red — confirmed via screenshot.

## Known follow-up (not fixed here, flagged for awareness)
If a required dropdown defaults to a literal `"-"` sentinel value (see `useItemFormFields.tsx`'s `getFieldValue`) and Zendesk's backend accepts that as satisfying the field's required-ness, no 422/field error comes back and `aria-invalid` never gets set — so that field won't render invalid even after a submit attempt. That would be a data/config question (which value a field defaults to, or how "required" is judged on the backend), not something CSS can fix.