### PR TITLE
Flag any required-and-empty field on submit, not just asset fields

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
@@ -154,7 +154,15 @@ describe("ServiceCatalogItem", () => {
       label: "Field 1",
       required: true,
       options: [],
-      value: null,
+      // Non-empty on purpose: this fixture is shared by every test in this
+      // file (see beforeEach below), most of which are about server
+      // response handling / on-behalf submission, not about required-field
+      // validation itself. Since useValidateServiceItemForm now correctly
+      // blocks the client-side submit when ANY required field is empty
+      // (see the dedicated "client-side required-field validation" tests
+      // below), leaving this field empty would incidentally block every
+      // other test's submission before it ever reaches the server.
+      value: "Field 1 value",
       error: null,
     },
   ];
@@ -373,6 +381,75 @@ describe("ServiceCatalogItem", () => {
 
       await waitFor(() => {
         expect(mockSubmitServiceItemRequest).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("client-side required-field validation", () => {
+    it("blocks submission and flags a required non-asset field left empty", async () => {
+      const setRequestFields = jest.fn();
+
+      mockUseItemFormFields.mockReturnValue({
+        requestFields: [
+          {
+            id: 1,
+            name: "custom_fields_1",
+            type: "text",
+            description: "Field 1",
+            label: "Field 1",
+            required: true,
+            options: [],
+            value: null,
+            error: null,
+          },
+        ],
+        associatedLookupField: mockAssociatedLookupField,
+        categoryLookupField: null,
+        error: null,
+        setRequestFields,
+        handleChange: jest.fn(),
+        isRequestFieldsLoading: false,
+        assetTypeHiddenValue: "",
+        isAssetTypeHidden: false,
+        assetTypeIds: [],
+        assetIds: [],
+      });
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      const form = screen.getByTestId("item-request-form");
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(setRequestFields).toHaveBeenCalledWith([
+          expect.objectContaining({
+            id: 1,
+            error: "This field is required.",
+          }),
+        ]);
+      });
+
+      // Client-side validation should stop the request before it ever
+      // reaches the network -- the field's own red highlight (driven by
+      // the `error` set above -> aria-invalid, see _svc-form-validation.scss)
+      // is the feedback, not a round trip to the server.
+      expect(mockSubmitServiceItemRequest).not.toHaveBeenCalled();
+    });
+
+    it("submits normally once the required field has a value", async () => {
+      const successResponse = {
+        ok: true,
+        json: () => Promise.resolve({ request: { id: 555 } }),
+      } as unknown as Response;
+      mockSubmitServiceItemRequest.mockResolvedValue(successResponse);
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      const form = screen.getByTestId("item-request-form");
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(mockSubmitServiceItemRequest).toHaveBeenCalled();
       });
     });
   });

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -252,11 +252,23 @@ export function ServiceCatalogItem({
     fields: TicketFieldObject[],
     attachments: Attachment[]
   ): boolean {
-    const { hasError, errors } = validate(fields, attachments);
+    const { hasError, errors, fieldErrors } = validate(fields, attachments);
 
     setAttachmentsRequiredError(errors.attachments);
     setAssetTypeError(errors.assetType);
     setAssetError(errors.asset);
+
+    // Merge the generic required-field errors directly onto each field's
+    // `error` prop, the same way handleValidationErrors() below merges
+    // server-returned errors -- this is what actually drives aria-invalid
+    // (see _svc-form-validation.scss). Runs fresh on every submit attempt,
+    // so any field not currently in fieldErrors is reset to no error.
+    setRequestFields(
+      fields.map((field) => ({
+        ...field,
+        error: fieldErrors[field.id] ?? null,
+      }))
+    );
 
     return hasError;
   }

--- a/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
+++ b/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
@@ -409,6 +409,122 @@ describe("useItemFormFields", () => {
     ]);
   });
 
+  it("should clear a field's error once handleChange gives it a value", async () => {
+    const formResponse = {
+      ticket_form: {
+        id: 1,
+        ticket_field_ids: [1, 2],
+        active: true,
+      },
+    };
+
+    const ticketFieldResponse = {
+      ticket_fields: [textField, lookupField],
+    };
+
+    (globalThis.fetch as jest.Mock) = jest.fn((url) => {
+      return url.includes("/api/v2/ticket_forms/1")
+        ? Promise.resolve({
+            json: () => Promise.resolve(formResponse),
+            status: 200,
+            ok: true,
+          })
+        : url.includes("/api/v2/ticket_fields?locale=en-us")
+        ? Promise.resolve({
+            json: () => Promise.resolve(ticketFieldResponse),
+            status: 200,
+            ok: true,
+          })
+        : {};
+    });
+
+    const { result } = renderHook(() =>
+      useItemFormFields(serviceCatalogItem, baseLocale)
+    );
+
+    await waitFor(() => {
+      expect(result.current.requestFields).toEqual([expectedTextField]);
+    });
+
+    // Simulate a required field that was flagged invalid on a prior submit
+    // attempt (mirroring what validateForm()/handleValidationErrors do in
+    // ServiceCatalogItem.tsx).
+    act(() => {
+      result.current.setRequestFields([
+        { ...expectedTextField, error: "This field is required." },
+      ]);
+    });
+
+    expect(result.current.requestFields[0].error).toBe(
+      "This field is required."
+    );
+
+    act(() => {
+      result.current.handleChange(
+        { ...expectedTextField, error: "This field is required." },
+        "Now filled in"
+      );
+    });
+
+    expect(result.current.requestFields[0].value).toBe("Now filled in");
+    expect(result.current.requestFields[0].error).toBeNull();
+  });
+
+  it("should not clear a field's error if handleChange gives it an empty value", async () => {
+    const formResponse = {
+      ticket_form: {
+        id: 1,
+        ticket_field_ids: [1, 2],
+        active: true,
+      },
+    };
+
+    const ticketFieldResponse = {
+      ticket_fields: [textField, lookupField],
+    };
+
+    (globalThis.fetch as jest.Mock) = jest.fn((url) => {
+      return url.includes("/api/v2/ticket_forms/1")
+        ? Promise.resolve({
+            json: () => Promise.resolve(formResponse),
+            status: 200,
+            ok: true,
+          })
+        : url.includes("/api/v2/ticket_fields?locale=en-us")
+        ? Promise.resolve({
+            json: () => Promise.resolve(ticketFieldResponse),
+            status: 200,
+            ok: true,
+          })
+        : {};
+    });
+
+    const { result } = renderHook(() =>
+      useItemFormFields(serviceCatalogItem, baseLocale)
+    );
+
+    await waitFor(() => {
+      expect(result.current.requestFields).toEqual([expectedTextField]);
+    });
+
+    act(() => {
+      result.current.setRequestFields([
+        { ...expectedTextField, error: "This field is required." },
+      ]);
+    });
+
+    act(() => {
+      result.current.handleChange(
+        { ...expectedTextField, error: "This field is required." },
+        ""
+      );
+    });
+
+    expect(result.current.requestFields[0].error).toBe(
+      "This field is required."
+    );
+  });
+
   it("should not include fields with type 'subject', type 'description', active false, or editable_in_portal false in requestFields", async () => {
     const formResponse = {
       ticket_form: {

--- a/src/modules/service-catalog/hooks/useItemFormFields.tsx
+++ b/src/modules/service-catalog/hooks/useItemFormFields.tsx
@@ -343,9 +343,23 @@ export function useItemFormFields(
 
   const handleChange = useCallback(
     (field: TicketFieldObject, value: TicketFieldObject["value"]) => {
+      const hasValue = Array.isArray(value)
+        ? value.length > 0
+        : value !== undefined && value !== null && value !== "";
+
       const updatedFields = allRequestFields.map((ticketField) =>
         ticketField.name === field.name
-          ? { ...ticketField, value }
+          ? {
+              ...ticketField,
+              value,
+              // Clear a previously-flagged required-field error the moment
+              // the user supplies a value, rather than leaving it red
+              // until their next submit attempt (see
+              // useValidateServiceItemForm.ts's generic fieldErrors and
+              // ServiceCatalogItem.tsx's validateForm/handleValidationErrors,
+              // which are the only other places `error` gets set/cleared).
+              error: hasValue ? null : ticketField.error,
+            }
           : ticketField
       );
 

--- a/src/modules/service-catalog/hooks/useValidateServiceItemForm.spec.ts
+++ b/src/modules/service-catalog/hooks/useValidateServiceItemForm.spec.ts
@@ -91,6 +91,7 @@ describe("useValidateServiceItemForm", () => {
         assetType: null,
         asset: null,
       });
+      expect(validationResult.fieldErrors).toEqual({});
     });
 
     it("returns no errors when optional fields are empty", () => {
@@ -356,14 +357,18 @@ describe("useValidateServiceItemForm", () => {
       expect(validationResult.hasError).toBe(false);
     });
 
-    it("ignores non-asset fields in validation", () => {
+    it("flags a required non-asset field generically instead of ignoring it", () => {
       const { result } = renderHook(() =>
         useValidateServiceItemForm(undefined)
       );
 
-      // A required text field without asset relationship should not trigger errors
+      // A required text field without an asset relationship used to be
+      // silently ignored by this hook (no client-side error at all),
+      // leaving it entirely up to a server round-trip to ever flag it.
+      // It must now get a generic required-field error instead.
       const fields = [
         createTextField({
+          id: 42,
           required: true,
           value: null,
           relationship_target_type: undefined,
@@ -372,10 +377,30 @@ describe("useValidateServiceItemForm", () => {
 
       const validationResult = result.current.validate(fields, []);
 
-      // No asset-related errors, even though field is required and empty
-      expect(validationResult.hasError).toBe(false);
+      expect(validationResult.hasError).toBe(true);
       expect(validationResult.errors.assetType).toBeNull();
       expect(validationResult.errors.asset).toBeNull();
+      expect(validationResult.fieldErrors[42]).toBe("This field is required.");
+    });
+
+    it("does not flag a required non-asset field once it has a value", () => {
+      const { result } = renderHook(() =>
+        useValidateServiceItemForm(undefined)
+      );
+
+      const fields = [
+        createTextField({
+          id: 42,
+          required: true,
+          value: "some answer",
+          relationship_target_type: undefined,
+        }),
+      ];
+
+      const validationResult = result.current.validate(fields, []);
+
+      expect(validationResult.hasError).toBe(false);
+      expect(validationResult.fieldErrors).toEqual({});
     });
   });
 });

--- a/src/modules/service-catalog/hooks/useValidateServiceItemForm.ts
+++ b/src/modules/service-catalog/hooks/useValidateServiceItemForm.ts
@@ -14,6 +14,12 @@ export interface ValidationErrors {
 export interface ValidationResult {
   hasError: boolean;
   errors: ValidationErrors;
+  // Generic per-field errors, keyed by field.id, for any required field
+  // left empty that ISN'T an asset/asset-type/attachments field (those
+  // already have their own dedicated error channel above). Merged onto
+  // requestFields by ServiceCatalogItem.tsx so it renders through the
+  // same `error` prop -> aria-invalid pipeline as server-returned errors.
+  fieldErrors: Record<string, string>;
 }
 
 function isAssetTypeField(field: TicketFieldObject): boolean {
@@ -49,6 +55,7 @@ export function useValidateServiceItemForm(
         assetType: null,
         asset: null,
       };
+      const fieldErrors: Record<string, string> = {};
 
       if (attachmentsOption) {
         const isRequired =
@@ -62,6 +69,11 @@ export function useValidateServiceItemForm(
         }
       }
 
+      const genericRequiredMessage = t(
+        "service-catalog.field-required-error",
+        "This field is required."
+      );
+
       for (const field of fields) {
         if (field.required && !hasFieldValue(field)) {
           if (isAssetTypeField(field)) {
@@ -74,15 +86,33 @@ export function useValidateServiceItemForm(
               "service-catalog.asset-required-error",
               "Select an asset"
             );
+          } else {
+            // Every other required field type (text, textarea, checkbox,
+            // date, dropdown, multiselect, tagger, lookup) has no
+            // dedicated error channel like assetType/asset/attachments
+            // do -- flag it here instead, keyed by field.id, so
+            // ServiceCatalogItem.tsx can merge it directly onto the
+            // field's `error` prop (which is what drives aria-invalid /
+            // the red highlight in _svc-form-validation.scss). Without
+            // this, a plain required field left empty silently passed
+            // client-side validation, and only ever got flagged if the
+            // *server* also rejected it and its 422 response happened to
+            // map back by field_key -- unreliable, and gave no feedback
+            // at all when that mapping didn't line up or the request
+            // never completed.
+            fieldErrors[field.id] = genericRequiredMessage;
           }
         }
       }
 
       const hasError = Boolean(
-        errors.attachments || errors.assetType || errors.asset
+        errors.attachments ||
+          errors.assetType ||
+          errors.asset ||
+          Object.keys(fieldErrors).length > 0
       );
 
-      return { hasError, errors };
+      return { hasError, errors, fieldErrors };
     },
     [attachmentsOption, t]
   );

--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -359,3 +359,8 @@ parts:
       title: "Line in the request comment naming the requester. {{name}} is that requester's name."
       screenshot: "https://drive.google.com/file/d/1DsOq3atb9velOovcY-abPqa41S4NNp9v/view?usp=sharing"
       value: "Requester: {{name}}"
+  - translation:
+      key: "service-catalog.field-required-error"
+      title: "Generic error message shown under a required service-catalog request field left empty on submit (any field type without its own dedicated message, e.g. text, dropdown, checkbox, tagger, date)"
+      screenshot: ""
+      value: "This field is required."

--- a/src/modules/service-catalog/translations/locales/en-us.json
+++ b/src/modules/service-catalog/translations/locales/en-us.json
@@ -25,6 +25,7 @@
   "service-catalog.empty-state.go-to-homepage": "Go to the homepage",
   "service-catalog.empty-state.no-services": "No services in sight",
   "service-catalog.empty-state.search-description": "Enter your keywords in the search field.",
+  "service-catalog.field-required-error": "This field is required.",
   "service-catalog.item.attachments-label": "Upload a file",
   "service-catalog.item.change-category": "Change category",
   "service-catalog.item.change-user-requesting-on-behalf": "Change",


### PR DESCRIPTION
## Root cause

Once `_svc-form-validation.scss` was correctly gated to only highlight on `[aria-invalid="true"]` (previous PR), red highlighting mostly stopped working — not because of the CSS, but because it exposed a real gap in `useValidateServiceItemForm.ts`'s client-side `validate()`:

```ts
for (const field of fields) {
  if (field.required && !hasFieldValue(field)) {
    if (isAssetTypeField(field)) { errors.assetType = ...; }
    else if (isAssetField(field)) { errors.asset = ...; }
    // nothing happens for any other required field type
  }
}
```

It loops over every field and correctly detects "required and empty," but only ever records an error for asset-type/asset fields. Every other required field type (plain text, generic dropdown, checkbox, textarea, tagger, lookup, date) silently passed client-side validation, `hasError` came back `false`, and the form submitted to the server anyway. `aria-invalid` (and the red highlight) for those fields only ever showed up if the server's 422 response happened to map a `field_key` back to that exact `field.id` — unreliable, and gave zero feedback when it didn't line up. The earlier interaction-based (`:user-invalid`) CSS had been accidentally masking this the whole time, since native HTML validity fires independent of whatever React does.

## Fix

- `useValidateServiceItemForm.ts`: added a generic `fieldErrors: Record<string, string>` map (keyed by `field.id`) populated for any required-and-empty field that isn't already covered by the asset/asset-type/attachments channels, using a new translatable message (`service-catalog.field-required-error`, "This field is required."). `hasError` now includes this too, so the client actually blocks submission instead of relying on a server round-trip.
- `ServiceCatalogItem.tsx`: `validateForm()` merges `fieldErrors` onto `requestFields` the same way `handleValidationErrors()` already merges server-returned errors — same pipeline, so it renders through `aria-invalid` identically.
- `useItemFormFields.tsx`: `handleChange` now clears a field's `error` the moment it receives a real value, so fixing a field un-highlights it immediately rather than waiting for the next submit attempt.
- Added `service-catalog.field-required-error` to `translations/en-us.yml` (via the local `i18n:extract` script) and `translations/locales/en-us.json`.

## Tests

- Updated the existing test that explicitly encoded the old "ignore non-asset fields" behavior, added coverage for the new generic flagging/clearing in both hooks.
- Fixed a shared test fixture in `ServiceCatalogItem.spec.tsx` (a required-but-empty non-asset field) that would have incidentally blocked several unrelated submission-path tests now that the check actually works, and added a dedicated pair of tests proving the new required-field blocking/success behavior.
- Full `service-catalog` suite (172 tests) passes; `yarn build` compiles cleanly with no new warnings.